### PR TITLE
fiftyone_degrees_interlock_dw_type_t align(16)

### DIFF
--- a/threading.h
+++ b/threading.h
@@ -417,7 +417,7 @@ typedef struct fiftyone_degrees_interlock_dw_type_t {
 typedef struct fiftyone_degrees_interlock_dw_type_t {
     int64_t low;
     int64_t high;
-} __attribute__((aligned(8),packed)) fiftyoneDegreesInterlockDoubleWidth;
+} __attribute__((aligned(16),packed)) fiftyoneDegreesInterlockDoubleWidth;
 #else // _LP64
 typedef struct fiftyone_degrees_interlock_dw_type_t {
     int64_t value;


### PR DESCRIPTION
fiftyone_degrees_interlock_dw_type_t is 16 bytes anyway, so should be aligned to 16 bytes without harm equal to its size, this prevents a warning on LP64 macOS:
```
error: misaligned atomic operation may incur significant performance penalty; the expected alignment (16 bytes) exceeds the actual alignment (8 bytes) [-Werror,-Watomic-alignment]
        } while (FIFTYONE_DEGREES_INTERLOCK_EXCHANGE_DW(
```