### PR TITLE
Fix warnings in Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.24)
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Minimum required versions for MSVC
 set (MIN_VS_TOOLSET_VERSION 142)

--- a/collection.c
+++ b/collection.c
@@ -828,7 +828,7 @@ fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromFile(
 			header.length = sizeOrCount;
 			header.count = elementSize > 0 ? header.length / elementSize : 0;
 		}
-		header.startPosition = ftell(file);
+		header.startPosition = (uint32_t)ftell(file);
 	}
 	else {
 		header.startPosition = 0;
@@ -1182,7 +1182,7 @@ long fiftyoneDegreesCollectionBinarySearch(
 	void *state,
 	fiftyoneDegreesCollectionItemComparer comparer,
 	fiftyoneDegreesException *exception) {
-	long upper = upperIndex,
+    uint32_t upper = upperIndex,
 		lower = lowerIndex,
 		middle;
 	int comparisonResult;

--- a/file.c
+++ b/file.c
@@ -210,7 +210,7 @@ static int getRandomString(
 	// names will be generated each time an executable is run.
 	long seed = getRandSeed();
 	if (seed == -1) {
-		return seed;
+		return -1;
 	}
 
 	srand((unsigned int)seed);

--- a/headers.c
+++ b/headers.c
@@ -27,6 +27,8 @@
 /* HTTP header prefix used when processing collections of parameters. */
 #define HTTP_PREFIX_UPPER "HTTP_"
 
+MAP_TYPE(HeaderID)
+
 /**
  * Counts the number of segments in a header name. 
  */
@@ -190,7 +192,7 @@ static bool setHeaderFromDataSet(
 	Header* header,
 	const char* name,
 	size_t nameLength,
-	uint32_t uniqueId) {
+    HeaderID uniqueId) {
 	if (copyHeaderName(header, name, nameLength) == false) {
 		return false;
 	}
@@ -256,15 +258,14 @@ static bool addHeadersFromDataSet(
 	HeadersGetMethod get,
 	HeaderArray* headers) {
 	Item item;
+    long uniqueId;
 	uint32_t index = 0;
 	const char* name;
 	size_t nameLength;
 	DataReset(&item.data);
 
 	// Get the first name item from the data set.
-    uint32_t uniqueId = (uint32_t)get(state, index, &item);
-	while (uniqueId >= 0) {
-
+	while ((uniqueId = get(state, index, &item)) >= 0) {
 		// Only include the header if it is not zero length, has at least one
 		// segment, and does not already exist in the collection.
 		name = STRING(item.data.ptr);
@@ -278,7 +279,7 @@ static bool addHeadersFromDataSet(
 				&headers->items[headers->count],
 				name,
 				nameLength,
-				uniqueId) == false) {
+				(HeaderID)uniqueId) == false) {
 				return false;
 			}
 
@@ -291,7 +292,6 @@ static bool addHeadersFromDataSet(
 
 		// Get the next name item from the data set.
 		index++;
-		uniqueId = (uint32_t)get(state, index, &item);
 	}
 	return true;
 }

--- a/headers.c
+++ b/headers.c
@@ -256,14 +256,13 @@ static bool addHeadersFromDataSet(
 	HeadersGetMethod get,
 	HeaderArray* headers) {
 	Item item;
-	long uniqueId;
 	uint32_t index = 0;
 	const char* name;
 	size_t nameLength;
 	DataReset(&item.data);
 
 	// Get the first name item from the data set.
-	uniqueId = get(state, index, &item);
+    uint32_t uniqueId = (uint32_t)get(state, index, &item);
 	while (uniqueId >= 0) {
 
 		// Only include the header if it is not zero length, has at least one
@@ -292,7 +291,7 @@ static bool addHeadersFromDataSet(
 
 		// Get the next name item from the data set.
 		index++;
-		uniqueId = get(state, index, &item);
+		uniqueId = (uint32_t)get(state, index, &item);
 	}
 	return true;
 }

--- a/headers.c
+++ b/headers.c
@@ -403,7 +403,7 @@ int fiftyoneDegreesHeaderGetIndex(
 
 fiftyoneDegreesHeader* fiftyoneDegreesHeadersGetHeaderFromUniqueId(
 	fiftyoneDegreesHeaders *headers,
-	uint32_t uniqueId) {
+	HeaderID uniqueId) {
 	uint32_t i;
 	for (i = 0; i < headers->count; i++) {
 		if (headers->items[i].uniqueId == uniqueId) {

--- a/headers.h
+++ b/headers.h
@@ -218,7 +218,7 @@ EXTERNAL int fiftyoneDegreesHeaderGetIndex(
  */
 EXTERNAL fiftyoneDegreesHeader* fiftyoneDegreesHeadersGetHeaderFromUniqueId(
 	fiftyoneDegreesHeaders *headers,
-	uint32_t uniqueId);
+    fiftyoneDegreesHeaderID uniqueId);
 
 /**
  * Frees the memory allocated by the #fiftyoneDegreesHeadersCreate method.

--- a/headers.h
+++ b/headers.h
@@ -116,6 +116,8 @@ FIFTYONE_DEGREES_ARRAY_TYPE(
 	fiftyoneDegreesHeaderSegment, 
 	);
 
+typedef uint32_t fiftyoneDegreesHeaderID;
+
 /**
  * Header structure to identify a header that either comes directly from the
  * data set, or one that forms a pseudo header.
@@ -128,7 +130,7 @@ typedef struct fiftyone_degrees_header_t {
 	fiftyoneDegreesHeaderSegmentArray* segments; /**< Segments within the 
 												      name */
 	bool isDataSet; /**< True if the header originates from the data set */
-	uint32_t uniqueId; /** < Unique id provided by the data set */
+    fiftyoneDegreesHeaderID uniqueId; /** < Unique id provided by the data set */
 } fiftyoneDegreesHeader;
 
 #define FIFTYONE_DEGREES_HEADERS_MEMBERS \

--- a/performance/CachePerf.c
+++ b/performance/CachePerf.c
@@ -106,9 +106,9 @@ fiftyoneDegreesCache *cache;
  * Prints a progress bar
  */
 void printLoadBar(performanceState *state) {
-	int i;
-	int full = state->count / state->progress;
-	int empty = (state->max - state->count) / state->progress;
+	long i;
+	const long full = state->count / state->progress;
+    const long empty = (state->max - state->count) / state->progress;
 
 	printf("\r\t[");
 	for (i = 0; i < full; i++) {

--- a/profile.c
+++ b/profile.c
@@ -282,7 +282,6 @@ uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyAndValue(
 	fiftyoneDegreesException *exception) {
 	uint32_t i, count = 0;
 	Item propertyItem, offsetItem, profileItem;
-	int valueIndex;
 	uint32_t *profileValueIndex, *maxProfileValueIndex;
 	Property *property;
 	Profile *profile;
@@ -295,8 +294,8 @@ uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyAndValue(
 		&propertyItem,
 		exception);
 	if (property != NULL && EXCEPTION_OKAY) {
-		valueIndex = fiftyoneDegreesValueGetIndexByName(
-			values, 
+		const long valueIndex = fiftyoneDegreesValueGetIndexByName(
+			values,
 			strings,
 			property, 
 			valueName,


### PR DESCRIPTION
### Changes
- Set `CMAKE_COMPILE_WARNING_AS_ERROR` `ON`.
- Bump required Cmake version to `3.24`.
- Fix warnings.

### Why
- https://github.com/51Degrees/common-cxx/issues/33