### PR TITLE
fix buffer overrun during pseudoheader construction

### DIFF
--- a/pseudoheader.c
+++ b/pseudoheader.c
@@ -98,7 +98,8 @@ static int constructPseudoEvidence(
         }
 
         // If this is a subsequent segment value then add the separator.
-        if (i != 0) {
+        // make sure that we don't cause heap overflow by overwriting the terminating \0 (at position max - 1)
+        if (i != 0 && current < max - 1) {
             *current = PSEUDO_HEADER_SEP;
             current++;
         }

--- a/tests/PseudoHeaderTests.hpp
+++ b/tests/PseudoHeaderTests.hpp
@@ -25,13 +25,14 @@
 #include "../evidence.h"
 #include "StringCollection.hpp"
 
+#define PSEUDO_BUFFER_SIZE 100
 typedef struct test_key_value_pair_t {
 	char key[50];
-	char value[50];
+	char value[PSEUDO_BUFFER_SIZE];
 } testKeyValuePair;
 
 typedef struct test_expected_result_t {
-	char result[50];
+	char result[PSEUDO_BUFFER_SIZE];
 	fiftyoneDegreesEvidencePrefix prefix;
 } testExpectedResult;
 


### PR DESCRIPTION
The heap buffer overrun could be caused by the separator written as a last character of the buffer and thus snprintf would get the size argument equal to 0 and would not be able to append `'\0'` at the end of the buffer.  