### PR TITLE
run-unit-tests: pass coverage pattern

### DIFF
--- a/ci/run-unit-tests.ps1
+++ b/ci/run-unit-tests.ps1
@@ -8,6 +8,7 @@ param(
 )
 
 # This is common logic, so let's call the common script
-./cxx/run-unit-tests.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod
+./cxx/run-unit-tests.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod `
+    -Coverages common
 
 exit $LASTEXITCODE


### PR DESCRIPTION
It's now required as an indicator that coverage is available.