### PR TITLE
ci: fix get-next-package-version

### DIFF
--- a/ci/get-next-package-version.ps1
+++ b/ci/get-next-package-version.ps1
@@ -1,1 +1,8 @@
-. ./cxx/get-next-package-version.ps1 @args
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$RepoName,
+    [Parameter(Mandatory=$true)]
+    [string]$VariableName
+)
+
+. ./cxx/get-next-package-version.ps1 -RepoName $RepoName -VariableName $VariableName


### PR DESCRIPTION
Allow run-repo-script to see common get-next-package-version params.