### PR TITLE
cmake enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,43 +155,43 @@ else ()
 endif()
 set_target_properties(CachePerf	PROPERTIES FOLDER "Examples/Common") 
 
-# Download and unpack googletest at configure time
-configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-	RESULT_VARIABLE result
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
-if(result)
-	message(FATAL_ERROR "-- CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-	RESULT_VARIABLE result
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
-if(result)
-	message(FATAL_ERROR "-- Build step for googletest failed: ${result}")
-endif()
-
-# Prevent overriding the parent project's compiler/linker
-# settings on Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-# Add googletest directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-	${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-	EXCLUDE_FROM_ALL)
-
-# The gtest/gtest_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
-	include_directories("${gtest_SOURCE_DIR}/include")
-endif()
-
-include(GoogleTest)
-
 # Tests
 
 if(BUILD_TESTING)
+	# Download and unpack googletest at configure time
+	configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in googletest-download/CMakeLists.txt)
+	execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+	if(result)
+		message(FATAL_ERROR "-- CMake step for googletest failed: ${result}")
+	endif()
+	execute_process(COMMAND ${CMAKE_COMMAND} --build .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+	if(result)
+		message(FATAL_ERROR "-- Build step for googletest failed: ${result}")
+	endif()
+
+	# Prevent overriding the parent project's compiler/linker
+	# settings on Windows
+	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+	# Add googletest directly to our build. This defines
+	# the gtest and gtest_main targets.
+	add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+		${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+		EXCLUDE_FROM_ALL)
+
+	# The gtest/gtest_main targets carry header search path
+	# dependencies automatically when using CMake 2.8.11 or
+	# later. Otherwise we have to add them here ourselves.
+	if (CMAKE_VERSION VERSION_LESS 2.8.11)
+		include_directories("${gtest_SOURCE_DIR}/include")
+	endif()
+
+	include(GoogleTest)
+
 	set(COM_TEST ${CMAKE_CURRENT_LIST_DIR}/tests)
 	FILE(GLOB COM_TEST_SRC ${COM_TEST}/*.cpp)
 	FILE(GLOB COM_TEST_H ${COM_TEST}/*.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ if(BUILD_TESTING)
 		target_link_libraries(CommonTests fiftyone-common-cxx gtest_main)
 	endif()
 
-	gtest_discover_tests(CommonTests PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
+	gtest_discover_tests(CommonTests PROPERTIES TEST_DISCOVERY_TIMEOUT 600 DISCOVERY_MODE PRE_TEST)
 	set_target_properties(CommonTests PROPERTIES FOLDER "Tests") 
 
 	if (CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
1. Download/unpack/include gtest only if BUILD_TESTING - addressing #54 
2. Fix `CommonTests` target build in Xcode generated project (`cmake . -G Xcode`) on macOS arm64, which was failing because of the https://gitlab.kitware.com/cmake/cmake/-/issues/21845 - macOS arm64 requires signed binary, but it is not signed in `POST_BUILD` when the discovery run, thus had to make test discovery `PRE_TEST`, rather than `POST_BUILD` (by default)