### PR TITLE
FEAT: Needs to handle null buffer to prevent combining headers when that feature is not needed.

### DIFF
--- a/evidence.c
+++ b/evidence.c
@@ -189,7 +189,12 @@ static bool processPseudoHeader(
 
 		// Add the header evidence that forms the segment if available updating
 		// the current buffer position if available.
-		bool success = addHeaderValueToBuilder(evidence, prefixes, header->segmentHeaders->items[i], builder, prependSeparator);
+		bool success = addHeaderValueToBuilder(
+			evidence, 
+			prefixes, 
+			header->segmentHeaders->items[i], 
+			builder, 
+			prependSeparator);
 
 		// If the pseudo header wasn't found, or insufficient space was 
 		// available to copy it, then return.
@@ -198,7 +203,8 @@ static bool processPseudoHeader(
 		}
 	}
 
-	// Append (or overwrite if it is the last character) a null terminating character.
+	// Append (or overwrite if it is the last character) a null terminating 
+	// character.
 	StringBuilderComplete(builder);
 
 	// A full header has been formed so call the callback with the buffer and
@@ -352,7 +358,8 @@ bool fiftyoneDegreesEvidenceIterateForHeaders(
 		// segment then that will be the header that was already processed in 
 		// processHeader therefore there is no point processing the same value
 		// a second time as a pseudo header.
-		if (header->segmentHeaders != NULL &&
+		if (buffer != NULL && 
+			header->segmentHeaders != NULL &&
 			header->segmentHeaders->count > 1) {
 			StringBuilderInit(&builder);
 			if (processPseudoHeader(

--- a/evidence.h
+++ b/evidence.h
@@ -275,6 +275,7 @@ EXTERNAL fiftyoneDegreesEvidenceKeyValuePair* fiftyoneDegreesEvidenceAddStringUn
     fiftyoneDegreesEvidencePrefix prefix,
     const char *field,
     const char *originalValue);
+
 /**
  * Iterates over the headers assembling the evidence values, considering the 
  * prefixes, in the buffer if available. The call back method is called for 
@@ -286,7 +287,8 @@ EXTERNAL fiftyoneDegreesEvidenceKeyValuePair* fiftyoneDegreesEvidenceAddStringUn
  * @param prefixes one or more prefix flags to return values for
  * @param state pointer passed to the callback method
  * @param headers to return evidence for if available
- * @param buffer that MIGHT be used with the callback
+ * @param buffer that MIGHT be used with the callback, null to disable 
+ * assembling headers
  * @param length of the buffer
  * @param callback method called when a matching prefix is found
  * @return true if the callback was called successfully, otherwise false


### PR DESCRIPTION
 If the buffer is not provided then the feature where headers are combined will be disabled. Needed for the GHEV feature where only single headers will be required.