### PR TITLE
FEAT: extend dynamically allocated evidence array by additionalCapacity

### DIFF
--- a/EvidenceBase.cpp
+++ b/EvidenceBase.cpp
@@ -26,7 +26,7 @@
 
 using namespace FiftyoneDegrees::Common;
 
-EvidenceBase::EvidenceBase() {
+EvidenceBase::EvidenceBase(size_t additionalCapacity): additionalCapacity(additionalCapacity) {
 	evidence = NULL;
 }
 
@@ -42,7 +42,8 @@ fiftyoneDegreesEvidenceKeyValuePairArray* EvidenceBase::get() {
 		EvidenceFree(evidence);
 		evidence = NULL;
 	}
-	evidence = EvidenceCreate((uint32_t)size());
+    // in case capacity has been provided as a hint
+	evidence = EvidenceCreate((uint32_t)(size() + additionalCapacity));
 	if (evidence != NULL) {
 		for (map<string, string>::const_iterator iterator = begin();
 			iterator != end();

--- a/EvidenceBase.cpp
+++ b/EvidenceBase.cpp
@@ -26,7 +26,7 @@
 
 using namespace FiftyoneDegrees::Common;
 
-EvidenceBase::EvidenceBase(size_t additionalCapacity): additionalCapacity(additionalCapacity) {
+EvidenceBase::EvidenceBase() {
 	evidence = NULL;
 }
 
@@ -42,13 +42,12 @@ fiftyoneDegreesEvidenceKeyValuePairArray* EvidenceBase::get() {
 		EvidenceFree(evidence);
 		evidence = NULL;
 	}
-    // in case capacity has been provided as a hint
-	evidence = EvidenceCreate((uint32_t)(size() + additionalCapacity));
+	evidence = EvidenceCreate((uint32_t)size());
 	if (evidence != NULL) {
 		for (map<string, string>::const_iterator iterator = begin();
 			iterator != end();
 			iterator++) {
-			EvidencePrefixMap *map = 
+			EvidencePrefixMap* map =
 				EvidenceMapPrefix(iterator->first.c_str());
 			if (map != NULL && isRelevant(map->prefixEnum)) {
 				EvidenceAddString(

--- a/EvidenceBase.hpp
+++ b/EvidenceBase.hpp
@@ -65,27 +65,16 @@ namespace FiftyoneDegrees {
 		 * ```
 		 */
 		class EvidenceBase : public map<string, string> {
-            size_t additionalCapacity;
 		public:
 			/**
 			 * @name Constructors and Destructors
 			 * @{
 			 */
 
-			/**
-			 * Construct a new instance containing no evidence.
-             * @param additionalCapacity - hint the additional capacity for the
-             *  dynamically allocated evidence array structure, to allow
-             *  derived evidence be added on the fly, when process() function is
-             *  called on the evidence.
-             *  The total capacity is the number of existing kv pairs plus this
-             *  additional capacity.
-             *  f.e. it may be necessary to expand 51d_gethighentropyvalues
-             *  into sec-ch-ua headers, thus the additional capacity must be 6.
-             *  If additional capacity is 0 - then the native evidence array will
-             *  have the capacity matching the number of key value pairs.
-			 */
-			EvidenceBase(size_t additionalCapacity = 0);
+			 /**
+			  * Construct a new instance containing no evidence.
+			  */
+			EvidenceBase();
 
 			/**
 			 * Free all the underlying memory containing the evidence.
@@ -98,12 +87,12 @@ namespace FiftyoneDegrees {
 			 * @{
 			 */
 
-			/**
-			 * Get the underlying C structure containing the evidence. This
-			 * only includes evidence which is relevant to the engine. Any
-			 * evidence which is irrelevant will not be included in the result.
-			 * @return pointer to a populated C evidence structure
-			 */
+			 /**
+			  * Get the underlying C structure containing the evidence. This
+			  * only includes evidence which is relevant to the engine. Any
+			  * evidence which is irrelevant will not be included in the result.
+			  * @return pointer to a populated C evidence structure
+			  */
 			fiftyoneDegreesEvidenceKeyValuePairArray* get();
 
 			/**
@@ -112,9 +101,9 @@ namespace FiftyoneDegrees {
 			 * @{
 			 */
 
-			/**
-			 * Clear all evidence items from the instance.
-			 */
+			 /**
+			  * Clear all evidence items from the instance.
+			  */
 			void clear();
 
 			/**
@@ -129,7 +118,7 @@ namespace FiftyoneDegrees {
 			 * @param last item to remove
 			 */
 			void erase(iterator first, iterator last);
-			
+
 			/**
 			 * @}
 			 */
@@ -144,7 +133,7 @@ namespace FiftyoneDegrees {
 			virtual bool isRelevant(fiftyoneDegreesEvidencePrefix prefix);
 		private:
 			/** The underlying evidence structure. */
-			fiftyoneDegreesEvidenceKeyValuePairArray *evidence;
+			fiftyoneDegreesEvidenceKeyValuePairArray* evidence;
 		};
 	}
 }

--- a/EvidenceBase.hpp
+++ b/EvidenceBase.hpp
@@ -65,6 +65,7 @@ namespace FiftyoneDegrees {
 		 * ```
 		 */
 		class EvidenceBase : public map<string, string> {
+            size_t additionalCapacity;
 		public:
 			/**
 			 * @name Constructors and Destructors
@@ -73,8 +74,18 @@ namespace FiftyoneDegrees {
 
 			/**
 			 * Construct a new instance containing no evidence.
+             * @param additionalCapacity - hint the additional capacity for the
+             *  dynamically allocated evidence array structure, to allow
+             *  derived evidence be added on the fly, when process() function is
+             *  called on the evidence.
+             *  The total capacity is the number of existing kv pairs plus this
+             *  additional capacity.
+             *  f.e. it may be necessary to expand 51d_gethighentropyvalues
+             *  into sec-ch-ua headers, thus the additional capacity must be 6.
+             *  If additional capacity is 0 - then the native evidence array will
+             *  have the capacity matching the number of key value pairs.
 			 */
-			EvidenceBase();
+			EvidenceBase(size_t additionalCapacity = 0);
 
 			/**
 			 * Free all the underlying memory containing the evidence.

--- a/evidence.c
+++ b/evidence.c
@@ -292,6 +292,9 @@ fiftyoneDegreesEvidenceCreate(uint32_t capacity) {
 
 void fiftyoneDegreesEvidenceFree(
 	fiftyoneDegreesEvidenceKeyValuePairArray *evidence) {
+    if (evidence == NULL) {
+        return;
+    }
 	EvidenceKeyValuePairArray* current = evidence;
 	while (current->next != NULL) {
 		current = current->next;

--- a/fiftyone.h
+++ b/fiftyone.h
@@ -287,6 +287,7 @@ MAP_TYPE(KeyValuePairArray)
 #define EvidenceCreate fiftyoneDegreesEvidenceCreate /**< Synonym for #fiftyoneDegreesEvidenceCreate function. */
 #define EvidenceMapPrefix fiftyoneDegreesEvidenceMapPrefix /**< Synonym for #fiftyoneDegreesEvidenceMapPrefix function. */
 #define EvidencePrefixString fiftyoneDegreesEvidencePrefixString /**< Synonym for #fiftyoneDegreesEvidencePrefixString function. */
+#define EvidenceAddPair fiftyoneDegreesEvidenceAddPair /**< Synonym for #fiftyoneDegreesEvidenceAddPair function. */
 #define EvidenceAddString fiftyoneDegreesEvidenceAddString /**< Synonym for #fiftyoneDegreesEvidenceAddString function. */
 #define PropertiesGetRequiredPropertyIndexFromName fiftyoneDegreesPropertiesGetRequiredPropertyIndexFromName /**< Synonym for #fiftyoneDegreesPropertiesGetRequiredPropertyIndexFromName function. */
 #define PropertiesGetNameFromRequiredIndex fiftyoneDegreesPropertiesGetNameFromRequiredIndex /**< Synonym for #fiftyoneDegreesPropertiesGetNameFromRequiredIndex function. */
@@ -358,6 +359,7 @@ MAP_TYPE(KeyValuePairArray)
 #define StringBuilderAddChars fiftyoneDegreesStringBuilderAddChars /**< Synonym for fiftyoneDegreesStringBuilderAddChars */
 #define StringBuilderComplete fiftyoneDegreesStringBuilderComplete /**< Synonym for fiftyoneDegreesStringBuilderComplete */
 #define EvidenceIterateMethod fiftyoneDegreesEvidenceIterateMethod /**< Synonym for fiftyoneDegreesEvidenceIterateMethod */
+#define OverrideHasValueForRequiredPropertyIndex fiftyoneDegreesOverrideHasValueForRequiredPropertyIndex /**< Synonym for fiftyoneDegreesOverrideHasValueForRequiredPropertyIndex */
 
 /* <-- only one asterisk to avoid inclusion in documentation
  * Shortened macros.

--- a/headers.c
+++ b/headers.c
@@ -77,7 +77,7 @@ static void initHeaders(Headers* headers) {
 		h->index = i;
 		h->headerId = 0;
 		h->isDataSet = false;
-		h->length = 0;
+		h->nameLength = 0;
 		h->name = NULL;
 		h->pseudoHeaders = NULL;
 		h->segmentHeaders = NULL;
@@ -181,7 +181,7 @@ static bool setHeaderName(
 		return false;
 	}
 	name[length] = '\0';
-	header->length = length;
+	header->nameLength = length;
 	return true;
 }
 
@@ -246,7 +246,7 @@ static Header* getHeader(Headers* headers, const char* name, size_t length) {
 	Header* item;
 	for (uint32_t i = 0; i < headers->count; i++) {
 		item = &headers->items[i];
-		if (item->length == length &&
+		if (item->nameLength == length &&
 			StringCompareLength(name, item->name, length) == 0) {
 			return item;
 		}
@@ -337,7 +337,7 @@ static Header* copyHeader(
 	if (setHeaderName(
 		copied, 
 		source->name, 
-		source->length, 
+		source->nameLength, 
 		exception) == false) {
 		return NULL;
 	}
@@ -401,7 +401,7 @@ static bool addHeadersFromHeader(
 	uint32_t start = 0;
 	uint32_t end = 0;
     bool separatorEncountered = false;
-	for (;end < pseudoHeader->length; end++) {
+	for (;end < pseudoHeader->nameLength; end++) {
 
 		// If a header has been found then either get the existing header with
 		// this name, or add a new header.
@@ -583,7 +583,7 @@ int fiftyoneDegreesHeaderGetIndex(
 	// Perform a case insensitive compare of the remaining characters.
 	for (i = 0; i < headers->count; i++) {
 		header = &headers->items[i];
-		if (header->length == length &&
+		if (header->nameLength == length &&
 			StringCompareLength(
 				httpHeaderName, 
 				header->name,

--- a/headers.h
+++ b/headers.h
@@ -138,7 +138,7 @@ struct fiftyone_degrees_header_t {
 	uint32_t index; /**< Index of the header in the array of all headers */
 	const char* name; /**< Name of the header or pseudo header field as a
 					       null terminated string */
-	size_t length; /**< Length of the name string excluding the terminating 
+	size_t nameLength; /**< Length of the name string excluding the terminating 
 						null */
 	fiftyoneDegreesHeaderID headerId; /**< Unique id in the data set for this 
 									  full header */
@@ -182,13 +182,6 @@ typedef long(*fiftyoneDegreesHeadersGetMethod)(
 	void *state,
 	uint32_t index, 
 	fiftyoneDegreesCollectionItem *nameItem);
-
-/**
- * Check if a header is a pseudo header.
- * @param headerName name of the header
- * @return whether a header is a pseudo header.
- */
-EXTERNAL bool fiftyoneDegreesHeadersIsPseudo(const char *headerName);
 
 /**
  * Creates a new headers instance configured with the unique HTTP names needed

--- a/overrides.c
+++ b/overrides.c
@@ -57,7 +57,8 @@ static void collectionRelease(Item *item) {
  * characters. Take 1 from the t to compare length.
  */
 #define IS_HEADER_MATCH(t,p) \
-	(StringCompareLength(skipPrefix(true, (char*)pair->field), t, sizeof(t)) == 0)
+	(StringCompareLength(\
+	skipPrefix(true, (char*)pair->item.key), t, sizeof(t)) == 0)
 
 static const Collection dummyCollection = { 
 	NULL, 
@@ -183,7 +184,7 @@ static bool addOverrideToResults(void *state, EvidenceKeyValuePair *pair) {
 	// Find the required property index, if any for the field.
 	int requiredPropertyIndex = getRequiredPropertyIndexFromName(
 		add->properties,
-		pair->field);
+		pair->item.key);
 
 	return fiftyoneDegreesOverridesAdd(
 		add->values,

--- a/pair.h
+++ b/pair.h
@@ -27,10 +27,10 @@
 #include <stddef.h>
 
 typedef struct fiftyone_degrees_key_value_pair_t {
-	char* key;
-	size_t keyLength;
-	char* value;
-	size_t valueLength;
+	const char* key; /**< pointer to the key string */
+	size_t keyLength; /**< number of characters in key */
+	const char* value; /**< pointer to the value string */
+	size_t valueLength; /**< number of characters in value */
 } fiftyoneDegreesKeyValuePair;
 
 FIFTYONE_DEGREES_ARRAY_TYPE(fiftyoneDegreesKeyValuePair, )

--- a/tests/EvidenceTests.cpp
+++ b/tests/EvidenceTests.cpp
@@ -439,6 +439,6 @@ TEST_F(Evidence, IterateForHeaders_SmallBuffer) {
 }
 
 TEST_F(Evidence, freeNullEvidence) {
-    fiftyoneDegreesEvidenceKeyValuePairArray *evidence = NULL;
-    EvidenceFree(evidence);
+    fiftyoneDegreesEvidenceKeyValuePairArray *evidence2 = NULL;
+    EvidenceFree(evidence2);
 }

--- a/tests/EvidenceTests.cpp
+++ b/tests/EvidenceTests.cpp
@@ -30,10 +30,10 @@ void assertStringHeaderAdded(
 	const char *expectedValue) {
 	EXPECT_EQ((int)pair->prefix, (int)FIFTYONE_DEGREES_EVIDENCE_HTTP_HEADER_STRING) <<
 		L"Expected 'header' prefix.";
-	EXPECT_STREQ(pair->field, expectedField) <<
-		L"Expected name '" << expectedField << "' not '" << pair->field << "'";
-	EXPECT_TRUE(strcmp((const char*)pair->originalValue, expectedValue) == 0) <<
-		L"Expected value '" << expectedValue << "' not '" << pair->originalValue << "'";
+	EXPECT_STREQ(pair->item.key, expectedField) <<
+		L"Expected name '" << expectedField << "' not '" << pair->item.key << "'";
+	EXPECT_TRUE(strcmp((const char*)pair->item.value, expectedValue) == 0) <<
+		L"Expected value '" << expectedValue << "' not '" << pair->item.value << "'";
 }
 
 TEST_F(Evidence, Get_PrefixString) {
@@ -99,9 +99,9 @@ TEST_F(Evidence, Add_MultipleStrings)
 #endif
 bool onMatchIterateString(void *state, fiftyoneDegreesEvidenceKeyValuePair *pair)
 {
-	if (strcmp((const char*)pair->field, "some-header-name") == 0) {
-		EXPECT_TRUE(strcmp((const char*)pair->originalValue, (const char*)pair->parsedValue) == 0) <<
-			L"Expected parsed value to be '" << (const char*)pair->originalValue << "' not '" <<
+	if (strcmp((const char*)pair->item.key, "some-header-name") == 0) {
+		EXPECT_TRUE(strcmp((const char*)pair->item.value, (const char*)pair->parsedValue) == 0) <<
+			L"Expected parsed value to be '" << (const char*)pair->item.value << "' not '" <<
 			(const char*)pair->parsedValue << "'";
 	}
 	return true;
@@ -203,9 +203,9 @@ TEST_F(Evidence, Iterate_String_without_pseudo_evidence) {
 		"Number of evidence should be 1\n";
 }
 
-bool callback1(void* state, fiftyoneDegreesHeader*, const char* value, size_t) {
+bool callback1(void* state, fiftyoneDegreesEvidenceKeyValuePair* pair) {
     std::vector<std::string> *results = (std::vector<std::string> *) state;
-    results->push_back(value);
+    results->push_back(pair->item.value);
     return true;
 }
 
@@ -361,9 +361,9 @@ TEST_F(Evidence, IterateForHeaders_ConstructPseudoHeader_Missing_or_Empty) {
     EXPECT_EQ(results[1], "\x1FGreen\x1F""Apple");
 }
 
-bool callback2(void* state, fiftyoneDegreesHeader* , const char* value, size_t ) {
+bool callback2(void* state, fiftyoneDegreesEvidenceKeyValuePair *pair) {
     std::vector<std::string> *results = (std::vector<std::string> *) state;
-    results->push_back(value);
+    results->push_back(pair->item.value);
     return results->size() <= 1; // on the second header we signal early exit by returning false
 }
 
@@ -388,7 +388,7 @@ TEST_F(Evidence, IterateForHeaders_CallbackSignalsEarlyExit) {
     EXPECT_EQ(results[1], "Big\x1FGreen");
 }
 
-bool callback_false(void* , fiftyoneDegreesHeader* , const char* , size_t ) {
+bool callback_false(void*, fiftyoneDegreesEvidenceKeyValuePair*) {
     return false;
 }
 

--- a/tests/EvidenceTests.cpp
+++ b/tests/EvidenceTests.cpp
@@ -438,4 +438,7 @@ TEST_F(Evidence, IterateForHeaders_SmallBuffer) {
     fiftyoneDegreesFree(buf);
 }
 
-
+TEST_F(Evidence, freeNullEvidence) {
+    fiftyoneDegreesEvidenceKeyValuePairArray *evidence = NULL;
+    EvidenceFree(evidence);
+}

--- a/tests/EvidenceWithHeadersTests_MultipleHeaders.cpp
+++ b/tests/EvidenceWithHeadersTests_MultipleHeaders.cpp
@@ -114,8 +114,8 @@ TEST_F(EvidenceWithHeadersTest_MultipleHeaders, Intersection_mh_se_sm) {
 		evidenceHeaderIntersection_mh_se_sm);
 
 	ASSERT_EQ(1, result);
-	ASSERT_STREQ("Black", intersection_mh_se_sm[0].field);
-	ASSERT_STREQ("Value", (char*)intersection_mh_se_sm[0].originalValue);
+	ASSERT_STREQ("Black", intersection_mh_se_sm[0].item.key);
+	ASSERT_STREQ("Value", (char*)intersection_mh_se_sm[0].item.value);
 }
 
 
@@ -160,10 +160,10 @@ TEST_F(EvidenceWithHeadersTest_MultipleHeaders, Intersection_mh_me_mm) {
 		evidenceHeaderIntersection_mh_me_mm);
 
 	ASSERT_EQ(2, result);
-	EXPECT_STREQ("Black", intersection_mh_me_mm[0].field);
-	EXPECT_STREQ("Value", (char*)intersection_mh_me_mm[0].originalValue);
-	EXPECT_STREQ("Red", intersection_mh_me_mm[1].field);
-	EXPECT_STREQ("Value2", (char*)intersection_mh_me_mm[1].originalValue);
+	EXPECT_STREQ("Black", intersection_mh_me_mm[0].item.key);
+	EXPECT_STREQ("Value", (char*)intersection_mh_me_mm[0].item.value);
+	EXPECT_STREQ("Red", intersection_mh_me_mm[1].item.key);
+	EXPECT_STREQ("Value2", (char*)intersection_mh_me_mm[1].item.value);
 }
 
 //------------------------------------------------------------------
@@ -177,8 +177,8 @@ bool evidenceHeaderIntersection_mh_me_nm(void *state,
 	fiftyoneDegreesEvidenceKeyValuePair *pair) {
 	if (fiftyoneDegreesHeaderGetIndex(
 		(fiftyoneDegreesHeaders*)state,
-		pair->field,
-		strlen(pair->field)) >= 0) {
+		pair->item.key,
+		pair->item.keyLength) >= 0) {
 		intersection_mh_me_nm[intersection_mh_me_nm_count] = *pair;
 		intersection_mh_me_nm_count++;
 	}

--- a/tests/EvidenceWithHeadersTests_NoHeaders.cpp
+++ b/tests/EvidenceWithHeadersTests_NoHeaders.cpp
@@ -81,8 +81,8 @@ bool evidenceHeaderIntersection_nh_se_nm(void *state,
 	fiftyoneDegreesEvidenceKeyValuePair *pair) {
 	if (fiftyoneDegreesHeaderGetIndex(
 		(fiftyoneDegreesHeaders*)state,
-		pair->field,
-		strlen(pair->field)) >= 0) {
+		pair->item.key,
+		pair->item.keyLength) >= 0) {
 		intersection_nh_se_nm[intersection_nh_se_nm_count] = *pair;
 		intersection_nh_se_nm_count++;
 	}
@@ -118,8 +118,8 @@ bool evidenceHeaderIntersection_nh_me_mm(void *state,
 	fiftyoneDegreesEvidenceKeyValuePair *pair) {
 	if (fiftyoneDegreesHeaderGetIndex(
 		(fiftyoneDegreesHeaders*)state,
-		pair->field,
-		strlen(pair->field)) >= 0) {
+		pair->item.key,
+		pair->item.keyLength) >= 0) {
 		intersection_nh_me_nm[intersection_multiple_nh_me_mm_count] = *pair;
 		intersection_multiple_nh_me_mm_count++;
 	}

--- a/tests/EvidenceWithHeadersTests_SingleHeader.cpp
+++ b/tests/EvidenceWithHeadersTests_SingleHeader.cpp
@@ -111,8 +111,8 @@ TEST_F(EvidenceWithHeadersTest_SingleHeader, Intersection_sh_se_sm) {
 		evidenceHeaderIntersection_sh_se_sm);
 
 	ASSERT_EQ(1, result);
-	ASSERT_STREQ("Red", intersection_sh_se_sm[0].field);
-	ASSERT_STREQ("Value", (char*)intersection_sh_se_sm[0].originalValue);
+	ASSERT_STREQ("Red", intersection_sh_se_sm[0].item.key);
+	ASSERT_STREQ("Value", (char*)intersection_sh_se_sm[0].item.value);
 }
 
 
@@ -130,8 +130,8 @@ bool evidenceHeaderIntersection_sh_me_mm(void *state,
 	fiftyoneDegreesEvidenceKeyValuePair *pair) {
 	if (fiftyoneDegreesHeaderGetIndex(
 		(fiftyoneDegreesHeaders*)state,
-		pair->field,
-		strlen(pair->field)) >= 0) {
+		pair->item.key,
+		pair->item.keyLength) >= 0) {
 		intersection_sh_me_sm[intersection_multiple_sh_me_mm_count] = *pair;
 		intersection_multiple_sh_me_mm_count++;
 	}
@@ -162,8 +162,8 @@ TEST_F(EvidenceWithHeadersTest_SingleHeader, Intersection_sh_me_sm) {
 
 	ASSERT_EQ(2, result);
 	ASSERT_EQ(1, intersection_multiple_sh_me_mm_count);
-	EXPECT_STREQ("Red", intersection_sh_me_sm[0].field);
-	EXPECT_STREQ("Value2", (char*)intersection_sh_me_sm[0].originalValue);
+	EXPECT_STREQ("Red", intersection_sh_me_sm[0].item.key);
+	EXPECT_STREQ("Value2", (char*)intersection_sh_me_sm[0].item.value);
 }
 
 //------------------------------------------------------------------
@@ -181,8 +181,8 @@ bool evidenceHeaderIntersection_sh_me_nm(void *state,
 	fiftyoneDegreesEvidenceKeyValuePair *pair) {
 	if (fiftyoneDegreesHeaderGetIndex(
 		(fiftyoneDegreesHeaders*)state,
-		pair->field,
-		strlen(pair->field)) >= 0) {
+		pair->item.key,
+		pair->item.keyLength) >= 0) {
 		intersection_sh_me_nm[intersection_sh_me_nm_count] = *pair;
 		intersection_sh_me_nm_count++;
 	}

--- a/tests/HeadersTests.cpp
+++ b/tests/HeadersTests.cpp
@@ -371,8 +371,8 @@ TEST_F(HeadersTests, PseudoHeadersPositive) {
 
 	EXPECT_STREQ("header1\x1Fheader2", headers->items[3].name);
 	EXPECT_EQ(2, headers->items[3].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[0]->length);
-	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[1]->length);
+	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[0]->nameLength);
+	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[1]->nameLength);
 	EXPECT_EQ(0, StringCompareLength(
 		"header1", 
 		headers->items[3].segmentHeaders->items[0]->name,
@@ -387,8 +387,8 @@ TEST_F(HeadersTests, PseudoHeadersPositive) {
 
 	EXPECT_STREQ("header2\x1Fheader3", headers->items[4].name);
 	EXPECT_EQ(2, headers->items[4].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[0]->length);
-	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[1]->length);
+	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[0]->nameLength);
+	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[1]->nameLength);
 	EXPECT_EQ(0, StringCompareLength(
 		"header2",
 		headers->items[4].segmentHeaders->items[0]->name,
@@ -403,9 +403,9 @@ TEST_F(HeadersTests, PseudoHeadersPositive) {
 
 	EXPECT_STREQ("header1\x1Fheader2\x1Fheader3", headers->items[5].name);
 	EXPECT_EQ(3, headers->items[5].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[0]->length);
-	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[1]->length);
-	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[2]->length);
+	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[0]->nameLength);
+	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[1]->nameLength);
+	EXPECT_EQ(7, headers->items[5].segmentHeaders->items[2]->nameLength);
 	
     EXPECT_EQ(0, StringCompareLength(
 		"header1",
@@ -445,11 +445,11 @@ TEST_F(HeadersTests, PseudoHeadersMissing) {
 	EXPECT_STREQ("header1\x1Fheader2", headers->items[0].name);
 	EXPECT_EQ(true, headers->items[0].isDataSet);
 	EXPECT_EQ(2, headers->items[0].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[0].segmentHeaders->items[0]->length);
+	EXPECT_EQ(7, headers->items[0].segmentHeaders->items[0]->nameLength);
     EXPECT_EQ(1, headers->items[0].segmentHeaders->items[0]->pseudoHeaders->count);
     EXPECT_EQ(&headers->items[0], headers->items[0].segmentHeaders->items[0]->pseudoHeaders->items[0]);
     
-	EXPECT_EQ(7, headers->items[0].segmentHeaders->items[1]->length);
+	EXPECT_EQ(7, headers->items[0].segmentHeaders->items[1]->nameLength);
     EXPECT_EQ(1, headers->items[0].segmentHeaders->items[1]->pseudoHeaders->count);
     EXPECT_EQ(&headers->items[0], headers->items[0].segmentHeaders->items[1]->pseudoHeaders->items[0]);
     
@@ -510,7 +510,7 @@ TEST_F(HeadersTests, PseudoHeadersSpecialCases) {
 
 	EXPECT_STREQ("\x1Fheader1", headers->items[2].name);
 	EXPECT_EQ(1, headers->items[2].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[2].segmentHeaders->items[0]->length);
+	EXPECT_EQ(7, headers->items[2].segmentHeaders->items[0]->nameLength);
 	EXPECT_EQ(0, StringCompareLength(
 		"header1",
 		headers->items[2].segmentHeaders->items[0]->name,
@@ -522,7 +522,7 @@ TEST_F(HeadersTests, PseudoHeadersSpecialCases) {
 
 	EXPECT_STREQ("header1\x1F", headers->items[3].name);
 	EXPECT_EQ(1, headers->items[3].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[0]->length);
+	EXPECT_EQ(7, headers->items[3].segmentHeaders->items[0]->nameLength);
 	EXPECT_EQ(0, StringCompareLength(
 		"header1",
 		headers->items[3].segmentHeaders->items[0]->name,
@@ -534,8 +534,8 @@ TEST_F(HeadersTests, PseudoHeadersSpecialCases) {
 
 	EXPECT_STREQ("header1\x1F\x1Fheader2", headers->items[4].name);
 	EXPECT_EQ(2, headers->items[4].segmentHeaders->count);
-	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[0]->length);
-	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[1]->length);
+	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[0]->nameLength);
+	EXPECT_EQ(7, headers->items[4].segmentHeaders->items[1]->nameLength);
 	EXPECT_EQ(0, StringCompareLength(
 		"header1",
 		headers->items[4].segmentHeaders->items[0]->name,

--- a/yamlfile.c
+++ b/yamlfile.c
@@ -85,15 +85,15 @@ static char* readNext(FileState* fileState) {
 // Sets the current and end pointers to the current key.
 static void setCurrentKey(PairState* state) {
 	KeyValuePair* current = state->pairs + state->index;
-	state->current = current->key;
-	state->end = current->key + current->keyLength - 1;
+	state->current = (char*)current->key;
+	state->end = (char*)(current->key + current->keyLength - 1);
 }
 
 // Sets the current and end pointers to the current value.
 static void setCurrentValue(PairState* state) {
 	KeyValuePair* current = state->pairs + state->index;
-	state->current = current->value;
-	state->end = current->value + current->valueLength - 1;
+	state->current = (char*)current->value;
+	state->end = (char*)current->value + current->valueLength - 1;
 }
 
 // Switches from writing to the current key to the current value. Ensures that
@@ -185,8 +185,8 @@ StatusCode fiftyoneDegreesYamlFileIterateWithLimit(
 		keyValuePairs,
 		collectionSize,
 		0,
-		keyValuePairs[0].key,
-		keyValuePairs[0].key + keyValuePairs[0].keyLength - 1 };
+		(char*)keyValuePairs[0].key,
+		(char*)(keyValuePairs[0].key + keyValuePairs[0].keyLength - 1) };
 
 	// If there is no limit then set the limit to the largest value to 
 	// avoid checking for negative values in the loop.
@@ -301,6 +301,5 @@ StatusCode fiftyoneDegreesYamlFileIterate(
 		collectionSize,
 		-1,
 		state,
-		callback
-	);
+		callback);
 }


### PR DESCRIPTION
in case derived evidence is to be added on the fly during device detection (f.e. derived from 51d_gethighentropyvalues)