### PR TITLE
BUG: iterating over empty evidence could segfault

### DIFF
--- a/array.h
+++ b/array.h
@@ -69,7 +69,7 @@ typedef struct fiftyone_degrees_array_##t##_t { \
 #define FIFTYONE_DEGREES_ARRAY_CREATE(t, i, c) \
 i = (t##Array*)fiftyoneDegreesMalloc(FIFTYONE_DEGREES_ARRAY_SIZE(t,c)); \
 if (i != NULL) { \
-i->items = (t*)(i + 1); \
+i->items = c ? (t*)(i + 1) : NULL; \
 i->count = 0; \
 i->capacity = c; \
 }

--- a/evidence.c
+++ b/evidence.c
@@ -94,14 +94,16 @@ static uint32_t evidenceIterate(
 
 		// Check the current evidence item and call back if the right prefix
 		// after parsing the pair if not done so already.
-		pair = &evidence->items[index++];
-		if ((pair->prefix & prefixes) == pair->prefix) {
-			if (pair->parsedValue == NULL) {
-				parsePair(pair);
-			}
-			cont = callback(state, pair);
-			iterations++;
-		}
+        if (index < evidence->count) {
+            pair = &evidence->items[index++];
+            if ((pair->prefix & prefixes) == pair->prefix) {
+                if (pair->parsedValue == NULL) {
+                    parsePair(pair);
+                }
+                cont = callback(state, pair);
+                iterations++;
+            }
+        }
 
 		// Check if the next evidence array needs to be moved to.
 		if (index >= evidence->count) {

--- a/tests/EvidenceTests.cpp
+++ b/tests/EvidenceTests.cpp
@@ -23,6 +23,9 @@
 #include "pch.h"
 #include "EvidenceTests.hpp"
 #include "memory.h"
+#include "../EvidenceBase.hpp"
+
+using namespace FiftyoneDegrees::Common;
 
 void assertStringHeaderAdded(
 	fiftyoneDegreesEvidenceKeyValuePair *pair,
@@ -441,4 +444,21 @@ TEST_F(Evidence, IterateForHeaders_SmallBuffer) {
 TEST_F(Evidence, freeNullEvidence) {
     fiftyoneDegreesEvidenceKeyValuePairArray *evidence2 = NULL;
     EvidenceFree(evidence2);
+}
+
+TEST_F(Evidence, emptyEvidence) {
+    EvidenceBase emptyEvidence;
+    //this produces an empty array, but items pointer is set to 1 past the end of array structure,
+    //so we do not always segfault if we attempt to iterate over it
+    //address sanitizer always reveals this heap overflow however
+    fiftyoneDegreesEvidenceKeyValuePairArray *emptyEvidenceKVPA = emptyEvidence.get();
+    
+    //ensure this is null so we segfault if we try to iterate
+    emptyEvidenceKVPA->items = nullptr;
+
+    std::vector<std::string> results;
+    auto iterations = EvidenceIterate(emptyEvidenceKVPA, FIFTYONE_DEGREES_EVIDENCE_QUERY,
+     &results, callback1);
+    
+    EXPECT_EQ(iterations, 0);
 }

--- a/tests/EvidenceTests.cpp
+++ b/tests/EvidenceTests.cpp
@@ -452,9 +452,6 @@ TEST_F(Evidence, emptyEvidence) {
     //so we do not always segfault if we attempt to iterate over it
     //address sanitizer always reveals this heap overflow however
     fiftyoneDegreesEvidenceKeyValuePairArray *emptyEvidenceKVPA = emptyEvidence.get();
-    
-    //ensure this is null so we segfault if we try to iterate
-    emptyEvidenceKVPA->items = nullptr;
 
     std::vector<std::string> results;
     auto iterations = EvidenceIterate(emptyEvidenceKVPA, FIFTYONE_DEGREES_EVIDENCE_QUERY,


### PR DESCRIPTION
When evidence was empty (f.e. when created in EvidenceBase::get()) it would create a 0 capacity array, with items pointing at an address 1 past the end of the structure in memory: 

array.h:
```c
#define FIFTYONE_DEGREES_ARRAY_SIZE(t, c) (sizeof(t##Array) + (sizeof(t) * (c)))
#define FIFTYONE_DEGREES_ARRAY_CREATE(t, i, c) \
i = (t##Array*)fiftyoneDegreesMalloc(FIFTYONE_DEGREES_ARRAY_SIZE(t,c)); \
if (i != NULL) { \
i->items = (t*)(i + 1); \ /* <--- this is always set regardless of capacity */
i->count = 0; \
i->capacity = c; \
}
```

This probably does not affect other arrays, but affects `evidence` at least in our tests (`EngineDeviceDetectionTests::verifyWithEmptyEvidence()`) - it did not segfault every time in CI - but address sanitizer revealed the problem 100% of times.  

The suggested patch rectifies the problem in the iterate method and adds a corresponding test, but probably could also be addressed at a macro level... 