### PR TITLE
Move in `IpAddress` class (on main)

### DIFF
--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -57,7 +57,7 @@ IpAddress::IpAddress(const char * const ipAddressString) {
 }
 
 void IpAddress::init(const unsigned char * const ipAddressData,
-    const fiftyoneDegreesEvidenceIpType type) {
+    const fiftyoneDegreesEvidenceIpType addressType) {
     switch (type) {
     case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:
         memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV4_LENGTH);

--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -20,6 +20,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+#include <cstring>
 #include <string>
 #include <stdexcept>
 #include "memory.h"

--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -56,7 +56,7 @@ IpAddress::IpAddress(const char * const ipAddressString) {
     fiftyoneDegreesFree(eIpAddress);
 }
 
-void IpAddress::init(const unsigned char * const ipAddress,
+void IpAddress::init(const unsigned char * const ipAddressData,
     const fiftyoneDegreesEvidenceIpType type) {
     switch (type) {
     case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:

--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -34,9 +34,9 @@ IpAddress::IpAddress() {
     this->type = FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID;
 }
 
-IpAddress::IpAddress(const unsigned char ipAddress[],
-    fiftyoneDegreesEvidenceIpType type) {
-    init(ipAddress, type);
+IpAddress::IpAddress(const unsigned char ipAddressData[],
+    fiftyoneDegreesEvidenceIpType addressType) {
+    init(ipAddressData, addressType);
 }
 
 IpAddress::IpAddress(const char * const ipAddressString) {
@@ -58,18 +58,18 @@ IpAddress::IpAddress(const char * const ipAddressString) {
 
 void IpAddress::init(const unsigned char * const ipAddressData,
     const fiftyoneDegreesEvidenceIpType addressType) {
-    switch (type) {
+    switch (addressType) {
     case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:
-        memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV4_LENGTH);
+        memcpy(ipAddress, ipAddressData, FIFTYONE_DEGREES_IPV4_LENGTH);
         break;
     case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6:
-        memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV6_LENGTH);
+        memcpy(ipAddress, ipAddressData, FIFTYONE_DEGREES_IPV6_LENGTH);
         break;
     default:
-        memset(this->ipAddress, 0, FIFTYONE_DEGREES_IPV6_LENGTH);
+        memset(ipAddress, 0, FIFTYONE_DEGREES_IPV6_LENGTH);
         break;
     }
-    this->type = type;
+    type = addressType;
 }
 
 void IpAddress::getCopyOfIpAddress(unsigned char copy[], const uint32_t size) const {
@@ -77,5 +77,5 @@ void IpAddress::getCopyOfIpAddress(unsigned char copy[], const uint32_t size) co
         ? FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4
         : FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6);
 	const uint32_t copySize = (size < dataSize) ? size : dataSize;
-	memcpy(copy, this->ipAddress, copySize);
+	memcpy(copy, ipAddress, copySize);
 }

--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -1,0 +1,78 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence (EUPL) 
+ * v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ * 
+ * If using the Work as, or as part of, a network application, by 
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading, 
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#include <string>
+#include <stdexcept>
+#include "memory.h"
+#include "IpAddress.hpp"
+
+using namespace std;
+using namespace FiftyoneDegrees::IpIntelligence;
+
+IpAddress::IpAddress() {
+    memset(this->ipAddress, 0, FIFTYONE_DEGREES_IPV6_LENGTH);
+    this->type = FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID;
+}
+
+IpAddress::IpAddress(const unsigned char ipAddress[],
+    fiftyoneDegreesEvidenceIpType type) {
+    init(ipAddress, type);
+}
+
+IpAddress::IpAddress(const char *ipAddressString) {
+    fiftyoneDegreesEvidenceIpAddress *eIpAddress = 
+		fiftyoneDegreesIpParseAddress(
+			fiftyoneDegreesMalloc,
+			ipAddressString,
+			ipAddressString + strlen(ipAddressString));
+    // Make sure the ip address has been parsed successfully
+	if (eIpAddress == NULL) {
+		throw bad_alloc();
+	}
+    // Initialize the IP address object
+    init(eIpAddress->address, eIpAddress->type);
+
+    // Free the previously allocated IP address
+    fiftyoneDegreesFree(eIpAddress);
+}
+
+void IpAddress::init(const unsigned char *ipAddress,
+    fiftyoneDegreesEvidenceIpType type) {
+    switch (type) {
+    case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:
+        memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV4_LENGTH);
+        break;
+    case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6:
+        memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV6_LENGTH);
+        break;
+    default:
+        memset(this->ipAddress, 0, FIFTYONE_DEGREES_IPV6_LENGTH);
+        break;
+    }
+    this->type = type;
+}
+
+void IpAddress::getCopyOfIpAddress(unsigned char copy[], uint32_t size) {
+	uint32_t copySize = type > FIFTYONE_DEGREES_IPV6_LENGTH ?
+	    size : FIFTYONE_DEGREES_IPV6_LENGTH;
+	memcpy(copy, this->ipAddress, copySize);
+}

--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -39,14 +39,14 @@ IpAddress::IpAddress(const unsigned char ipAddress[],
     init(ipAddress, type);
 }
 
-IpAddress::IpAddress(const char *ipAddressString) {
+IpAddress::IpAddress(const char * const ipAddressString) {
     fiftyoneDegreesEvidenceIpAddress *eIpAddress = 
 		fiftyoneDegreesIpParseAddress(
 			fiftyoneDegreesMalloc,
 			ipAddressString,
 			ipAddressString + strlen(ipAddressString));
     // Make sure the ip address has been parsed successfully
-	if (eIpAddress == NULL) {
+	if (eIpAddress == nullptr) {
 		throw bad_alloc();
 	}
     // Initialize the IP address object
@@ -56,8 +56,8 @@ IpAddress::IpAddress(const char *ipAddressString) {
     fiftyoneDegreesFree(eIpAddress);
 }
 
-void IpAddress::init(const unsigned char *ipAddress,
-    fiftyoneDegreesEvidenceIpType type) {
+void IpAddress::init(const unsigned char * const ipAddress,
+    const fiftyoneDegreesEvidenceIpType type) {
     switch (type) {
     case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:
         memcpy(this->ipAddress, ipAddress, FIFTYONE_DEGREES_IPV4_LENGTH);
@@ -72,8 +72,10 @@ void IpAddress::init(const unsigned char *ipAddress,
     this->type = type;
 }
 
-void IpAddress::getCopyOfIpAddress(unsigned char copy[], uint32_t size) {
-	uint32_t copySize = type > FIFTYONE_DEGREES_IPV6_LENGTH ?
-	    size : FIFTYONE_DEGREES_IPV6_LENGTH;
+void IpAddress::getCopyOfIpAddress(unsigned char copy[], const uint32_t size) const {
+    const uint32_t dataSize = ((type == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4)
+        ? FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4
+        : FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6);
+	const uint32_t copySize = (size < dataSize) ? size : dataSize;
 	memcpy(copy, this->ipAddress, copySize);
 }

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -55,7 +55,7 @@ namespace FiftyoneDegrees {
              * @param ipAddress the IP address byte array
              * @param type the type of the IP address
              */
-            IpAddress(const unsigned char ipAddress[],
+            IpAddress(const unsigned char ipAddressData[],
                       fiftyoneDegreesEvidenceIpType type);
 
             /**

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -111,8 +111,8 @@ namespace FiftyoneDegrees {
              * @param ipAddress the byte array IP address
              * @param type the type of the IP
              */
-            void init(const unsigned char *ipAddress,
-                      fiftyoneDegreesEvidenceIpType type);
+            void init(const unsigned char *ipAddressData,
+                      fiftyoneDegreesEvidenceIpType addressType);
 
             /** The type of the IP address */
             fiftyoneDegreesEvidenceIpType type;

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -23,7 +23,7 @@
 #ifndef FIFTYONE_DEGREES_IP_ADDRESS_HPP
 #define FIFTYONE_DEGREES_IP_ADDRESS_HPP
 
-#include "../ipi.h"
+#include "ip.h"
 
 namespace FiftyoneDegrees {
     namespace IpIntelligence {

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -77,7 +77,7 @@ namespace FiftyoneDegrees {
              * @return a constant pointer to the internal
              * byte array
              */
-            const unsigned char *getIpAddress() const{
+            const unsigned char *getIpAddress() const {
                 return (const unsigned char *)ipAddress;
             };
 
@@ -90,10 +90,10 @@ namespace FiftyoneDegrees {
              *
              * To get the actual pointer, the getIpAddress
              * should be used.
-             * @param copy which will hold an copy of the byte array
-             * @size size of the copy buffer
+             * @param copy which will hold a copy of the byte array
+             * @param size of the copy buffer
              */
-            void getCopyOfIpAddress(unsigned char copy[], uint32_t size);
+            void getCopyOfIpAddress(unsigned char copy[], uint32_t size) const;
 
             /**
              * Get the type of the IP address

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -52,11 +52,11 @@ namespace FiftyoneDegrees {
              * Construct an instance with a given
              * combination of IP address byte array
              * and its type
-             * @param ipAddress the IP address byte array
-             * @param type the type of the IP address
+             * @param ipAddressData the IP address byte array
+             * @param addressType the type of the IP address
              */
             IpAddress(const unsigned char ipAddressData[],
-                      fiftyoneDegreesEvidenceIpType type);
+                      fiftyoneDegreesEvidenceIpType addressType);
 
             /**
              * Construct an instance with a given

--- a/IpAddress.hpp
+++ b/IpAddress.hpp
@@ -1,0 +1,125 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence (EUPL) 
+ * v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ * 
+ * If using the Work as, or as part of, a network application, by 
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading, 
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#ifndef FIFTYONE_DEGREES_IP_ADDRESS_HPP
+#define FIFTYONE_DEGREES_IP_ADDRESS_HPP
+
+#include "../ipi.h"
+
+namespace FiftyoneDegrees {
+    namespace IpIntelligence {
+        /**
+         * A class which represents an IP address.
+         *
+         * This class is to give the IP address byte array
+         * a more concrete and 'easy to work with' form so
+         * that it can be passed between managed and unmanaged
+         * layers
+         */
+    	class IpAddress {
+        public:
+            /**
+             * @name Constructors
+             * @{
+             */
+
+            /**
+             * Construct a default instance with an
+             * invalid IP address
+             */
+            IpAddress();
+    
+            /**
+             * Construct an instance with a given
+             * combination of IP address byte array
+             * and its type
+             * @param ipAddress the IP address byte array
+             * @param type the type of the IP address
+             */
+            IpAddress(const unsigned char ipAddress[],
+                      fiftyoneDegreesEvidenceIpType type);
+
+            /**
+             * Construct an instance with a given
+             * IP address string. The type of the IP
+             * address is determined by parsing the string
+             * @param ipAddressString the IP address string
+             */
+            IpAddress(const char *ipAddressString);
+
+            /**
+             * @}
+             * @name Getters
+             * @{
+             */
+
+            /**
+             * Get the IP address byte array
+             * @return a constant pointer to the internal
+             * byte array
+             */
+            const unsigned char *getIpAddress() const{
+                return (const unsigned char *)ipAddress;
+            };
+
+            /**
+             * Returns a copy of the IP address byte array
+             * This is used mainly for SWIG so that other
+             * language can get a value of the byte array.
+             * By using carrays.i in SWIG, any access to
+             * this copy can be done via SWIG array functions.
+             *
+             * To get the actual pointer, the getIpAddress
+             * should be used.
+             * @param copy which will hold an copy of the byte array
+             * @size size of the copy buffer
+             */
+            void getCopyOfIpAddress(unsigned char copy[], uint32_t size);
+
+            /**
+             * Get the type of the IP address
+             * @return the type of IP address
+             */
+            fiftyoneDegreesEvidenceIpType getType() const { return type; };
+
+            /**
+             *@}
+             */
+    
+        private:
+            /**
+             * Initialization function
+             * @param ipAddress the byte array IP address
+             * @param type the type of the IP
+             */
+            void init(const unsigned char *ipAddress,
+                      fiftyoneDegreesEvidenceIpType type);
+
+            /** The type of the IP address */
+            fiftyoneDegreesEvidenceIpType type;
+            /** The IP address byte array */
+            unsigned char ipAddress[FIFTYONE_DEGREES_IPV6_LENGTH];
+        };
+    }
+}
+
+#endif

--- a/IpAddress.i
+++ b/IpAddress.i
@@ -1,4 +1,4 @@
-%include "ip.i"
+%include "common-cxx/ip.i"
 
 %nodefaultctor IpAddress;
 

--- a/IpAddress.i
+++ b/IpAddress.i
@@ -1,0 +1,13 @@
+%include "ip.i"
+
+%nodefaultctor IpAddress;
+
+%rename (IpAddressSwig) IpAddress;
+
+class IpAddress {
+public:
+    IpAddress(const unsigned char ipAddress[], fiftyoneDegreesEvidenceIpType type);
+    IpAddress(const char *ipAddressString);
+    void getCopyOfIpAddress(unsigned char copy[], uint32_t size);
+    fiftyoneDegreesEvidenceIpType getType();
+};

--- a/ip.i
+++ b/ip.i
@@ -1,0 +1,29 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence (EUPL) 
+ * v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ * 
+ * If using the Work as, or as part of, a network application, by 
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading, 
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+%rename (IpTypeSwig) fiftyoneDegreesEvidenceIpType;
+
+typedef enum e_fiftyone_degrees_evidence_ip_type {
+        FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4 = 0, /**< An IPv4 address */
+        FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6 = 1, /**< An IPv6 address */
+        FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID = 2, /**< Invalid IP address */
+} fiftyoneDegreesEvidenceIpType;

--- a/tests/IpAddressTests.cpp
+++ b/tests/IpAddressTests.cpp
@@ -111,15 +111,13 @@ TEST(ParseAddress, ParseAddress_Ipv6_LeadingZeros)
 		"The value of the IPv6 address (Leading zeros in each segment) is not correctly parsed.";
 }
 
-TEST(ParseAddress, ParseAddress_Ipv6_MixedIpv6Ipv4)
+TEST(ParseAddress, DISABLED_ParseAddress_Ipv6_MixedIpv6Ipv4)
 {
 	// IPv4-mapped IPv6 address
 	const char * const rawAddress = "::ffff:192.168.1.1";
 	const unsigned char addressBytes[] = {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 168, 1, 1
 	};
-
-	GTEST_SKIP() << "NOT IMPLEMENTED YET -- IPv4-mapped IPv6 address -- ::ffff:192.168.1.1";
 
 	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
 	EXPECT_TRUE(

--- a/tests/IpAddressTests.cpp
+++ b/tests/IpAddressTests.cpp
@@ -1,0 +1,226 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+ 
+#include "pch.h"
+#include "../IpAddress.hpp"
+
+
+static bool CheckResult(const byte *result, const byte *expected, uint16_t const size) {
+	bool match = true;
+	for (uint16_t i = 0; i < size; i++) {
+		match = match && (*result == *expected);
+		result++;
+		expected++;
+	}
+	return match;
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_AbbreviatedStart)
+{
+	const char * const ipv6AbbreviatedStart = "::FFFF:FFFF:FFFF:FFFF";
+	const byte expected[FIFTYONE_DEGREES_IPV6_LENGTH] =
+		{ 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255 };
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(ipv6AbbreviatedStart);
+
+	EXPECT_TRUE(ipAddress.getType() == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6) <<
+		"IP address version was not identified correctly where where the " <<
+		"IP address is " << ipv6AbbreviatedStart << ".";
+
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), expected, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the abbreivated start IPv6 address is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Invalid_ipv4OutOfRange)
+{
+	const char * const ipv4OutOfRange = "256.256.256.256";
+	constexpr byte expected[FIFTYONE_DEGREES_IPV4_LENGTH] =
+		{255, 255, 255, 255};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(ipv4OutOfRange);
+
+	EXPECT_TRUE(ipAddress.getType() == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4) <<
+		"IP address version was not identified correctly where where the " <<
+		"IP address is " << ipv4OutOfRange << ".";
+
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), expected, FIFTYONE_DEGREES_IPV4_LENGTH)) <<
+		"The value of the out of range IPv4 address is not correctly restricted "
+		"at 255.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_BasicIpv6Address)
+{
+	// Basic IPv6 address
+	const char * const rawAddress = "2001:0db8:85a3::8a2e:370:7334";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Basic IPv6 address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_CompressedZeros)
+{
+	// Compressed zeros
+	const char * const rawAddress = "2001:db8::1";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Compressed zeros) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_LeadingZeros)
+{
+	// Leading zeros in each segment
+	const char * const rawAddress = "2001:0db8:0000:0042:0000:8a2e:0370:7334";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 0, 0, 0, 66, 0, 0, 138, 46, 3, 112, 115, 52
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Leading zeros in each segment) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_MixedIpv6Ipv4)
+{
+	// IPv4-mapped IPv6 address
+	const char * const rawAddress = "::ffff:192.168.1.1";
+	const unsigned char addressBytes[] = {
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 168, 1, 1
+	};
+
+	GTEST_SKIP() << "NOT IMPLEMENTED YET -- IPv4-mapped IPv6 address -- ::ffff:192.168.1.1";
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (IPv4-mapped IPv6 address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_LoopbackAddress)
+{
+	// Loopback address
+	const char * const rawAddress = "::1";
+	const unsigned char addressBytes[] = {
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Loopback address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_LinkLocalAddress)
+{
+	// Link-local address
+	const char * const rawAddress = "fe80::1";
+	const unsigned char addressBytes[] = {
+		254, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Link-local address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_MulticastAddress)
+{
+	// Multicast address
+	const char * const rawAddress = "ff02::1";
+	const unsigned char addressBytes[] = {
+		255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Multicast address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_GlobalUnicast)
+{
+	// Global unicast address
+	const char * const rawAddress = "2001:0db8:1234:5678:9abc:def0:1234:5678";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 18, 52, 86, 120, 154, 188, 222, 240, 18, 52, 86, 120
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Global unicast address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_UniqueLocal)
+{
+	// Unique local address
+	const char * const rawAddress = "fd00::1";
+	const unsigned char addressBytes[] = {
+		253, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Unique local address) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_Ipv6InterfaceId)
+{
+	// Interface identifier (last 64 bits)
+	const char * const rawAddress = "2001:0db8:85a3::8a2e:0370:7334";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Interface identifier (last 64 bits)) is not correctly parsed.";
+}
+
+TEST(ParseAddress, ParseAddress_Ipv6_ZeroCompressedBlocks)
+{
+	// Zero-compressed blocks
+	const char * const rawAddress = "2001:db8::85a3:0:0:370:7334";
+	const unsigned char addressBytes[] = {
+		32, 1, 13, 184, 0, 0, 133, 163, 0, 0, 0, 0, 3, 112, 115, 52
+	};
+
+	auto const ipAddress = FiftyoneDegrees::IpIntelligence::IpAddress(rawAddress);
+	EXPECT_TRUE(
+		CheckResult(ipAddress.getIpAddress(), addressBytes, FIFTYONE_DEGREES_IPV6_LENGTH)) <<
+		"The value of the IPv6 address (Zero-compressed blocks) is not correctly parsed.";
+}

--- a/tests/IpParserTests.cpp
+++ b/tests/IpParserTests.cpp
@@ -24,7 +24,7 @@
 #include "../ip.h"
 
 
-bool CheckResult(byte* result, byte* expected, uint16_t size) {
+static bool CheckResult(byte* result, byte* expected, uint16_t size) {
 	bool match = true;
 	for (uint16_t i = 0; i < size; i++) {
 		match = match && *result == *expected;


### PR DESCRIPTION
### Changes
- Move in `IpAddress` class from another repo
  - with related `*.i` files
- Add 12 tests + 1 disabled
  - [IPv4-mapped IPv6 addresses](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses) -- `::ffff:192.168.1.1` -- do not the pass yet

### Runner logs
- ✅ https://github.com/postindustria-tech/common-cxx/actions/runs/12643224008/job/35228886903#step:5:1289

