### PR TITLE
Fix ParseAddress_Ipv6_MixedIpv6Ipv4 test (on main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ These can be run by calling
 ctest
 ```
 
+CTest module automatically creates a `BUILD_TESTING` option -- see https://cmake.org/cmake/help/latest/module/CTest.html
+
+When testing some dependent code, running `CommonTests` can be skipped by turning OFF the `FIFTYONE_COMMON_CXX_BUILD_TESTING` option.
+
 If CMake has been used in an MSVC environment, then the tests will be set up and discoverable in the Visual Studio solution `51DegreesCommon` created by CMake.
 
 ## Visual Studio

--- a/ip.c
+++ b/ip.c
@@ -26,7 +26,7 @@
 
 typedef void(*parseIterator)(
 	void *state,
-	EvidenceIpType type,
+	EvidenceIpType segmentType,
 	const char *start,
 	const char *end);
 
@@ -35,13 +35,13 @@ typedef void(*parseIterator)(
  */
 static void callbackIpAddressCount(
 	void *state,
-	EvidenceIpType type,
+	EvidenceIpType segmentType,
 	const char *start,
 	const char *end) {
 	if (start <= end) {
-		if (type != FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID) {
+		if (segmentType != FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID) {
 			(*(int*)state)++;
-			if (type == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6) {
+			if (segmentType == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6) {
 				(*(int*)state)++;
 			}
 		}
@@ -99,27 +99,48 @@ static void parseIpV6Segment(
 
 static void callbackIpAddressBuild(
 	void *state,
-	EvidenceIpType type,
+	EvidenceIpType segmentType,
 	const char *start,
 	const char *end) {
 	EvidenceIpAddress *address = (EvidenceIpAddress*)state;
-	if (type == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4) {
+	if (segmentType == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4) {
 		*address->current = getIpByte(atoi(start));
 		address->current++;
 	}
-	else if (type == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6) {
+	else if (segmentType == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6) {
 		parseIpV6Segment(address, start, end);
 	}
 }
 
-static EvidenceIpType getIpTypeFromSeparator(char separator) {
+static EvidenceIpType getIpTypeFromSeparator(const char separator) {
 	switch (separator) {
-	case '.':
-		return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4;
-	case ':':
-		return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6;
-	default:
-		return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID;
+		case '.':
+			return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4;
+		case ':':
+			return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6;
+		default:
+			return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID;
+	}
+}
+
+static EvidenceIpType getSegmentTypeWithSeparator(
+	const char separator,
+	const EvidenceIpType ipType,
+	const EvidenceIpType lastSeparatorType) {
+	switch (ipType) {
+		case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4:
+			return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4;
+		case FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6:
+			switch (separator) {
+				case ':':
+					return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV6;
+				case '.':
+					return FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_IPV4;
+				default:
+					return lastSeparatorType;
+			}
+		default:
+			return getIpTypeFromSeparator(separator);
 	}
 }
 
@@ -135,18 +156,20 @@ static EvidenceIpType iterateIpAddress(
 	parseIterator foundSegment) {
 	const char *current = start;
 	const char *nextSegment = current;
+	EvidenceIpType currentSegmentType = FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID;
 	while (current <= end && nextSegment < end) {
 		if (*current == ',' ||
 			*current == ':' ||
 			*current == '.' ||
 			*current == ' ' ||
 			*current == '\0') {
+			currentSegmentType = getSegmentTypeWithSeparator(*current, type, currentSegmentType);
 			if (type == FIFTYONE_DEGREES_EVIDENCE_IP_TYPE_INVALID) {
-				type = getIpTypeFromSeparator(*current);
+				type = currentSegmentType;
 			}
 			// Check if it is leading abbreviation
 			if (current - 1 >= start) {
-				foundSegment(state, type, nextSegment, current - 1);
+				foundSegment(state, currentSegmentType, nextSegment, current - 1);
 			}
 			nextSegment = current + 1;
 		}

--- a/tests/IpAddressTests.cpp
+++ b/tests/IpAddressTests.cpp
@@ -111,7 +111,7 @@ TEST(ParseAddress, ParseAddress_Ipv6_LeadingZeros)
 		"The value of the IPv6 address (Leading zeros in each segment) is not correctly parsed.";
 }
 
-TEST(ParseAddress, DISABLED_ParseAddress_Ipv6_MixedIpv6Ipv4)
+TEST(ParseAddress, ParseAddress_Ipv6_MixedIpv6Ipv4)
 {
 	// IPv4-mapped IPv6 address
 	const char * const rawAddress = "::ffff:192.168.1.1";


### PR DESCRIPTION
### Changes

- Update IPv6 parsing method to allow for IPv4-embedded addresses
  - `2001:db8:122:344::192.0.2.33` / `64:ff9b::192.0.2.33`
  - ^ see RFC 6052 -- "**IPv6 Addressing of IPv4/IPv6 Translators**" / "2.4. **Text Representation**"
    - https://datatracker.ietf.org/doc/html/rfc6052#section-2.4
- Mention `FIFTYONE_COMMON_CXX_BUILD_TESTING` in README

### Runner logs
- ✅ https://github.com/postindustria-tech/common-cxx/actions/runs/12658829378/job/35276635726#step:5:1290

### Related
- https://github.com/51Degrees/common-cxx/pull/67
- https://github.com/51Degrees/common-cxx/pull/68