### PR TITLE
Restore `const`-ness of `char*` in string.c/h (on v4.5)

### DIFF
--- a/string.c
+++ b/string.c
@@ -86,7 +86,7 @@ int fiftyoneDegreesStringCompareLength(
 	return 0;
 }
 
-char *fiftyoneDegreesStringSubString(const char *a, const char *b) {
+const char *fiftyoneDegreesStringSubString(const char *a, const char *b) {
 	int d;
 	const char *a1, *b1;
 	for (; *a != '\0' && *b != '\0'; a++) {
@@ -148,7 +148,7 @@ fiftyoneDegreesStringBuilder* fiftyoneDegreesStringBuilderAddInteger(
 
 fiftyoneDegreesStringBuilder* fiftyoneDegreesStringBuilderAddChars(
 	fiftyoneDegreesStringBuilder* builder,
-	char* const value,
+	const char * const value,
 	size_t const length) {
 	if (length < builder->remaining &&
 		memcpy(builder->current, value, length) == builder->current) {

--- a/string.h
+++ b/string.h
@@ -195,7 +195,7 @@ EXTERNAL int fiftyoneDegreesStringCompare(const char *a, const char *b);
  * @param b substring to be searched for
  * @return pointer to the first occurrence or NULL if not found
  */
-EXTERNAL char *fiftyoneDegreesStringSubString(const char *a, const char *b);
+EXTERNAL const char *fiftyoneDegreesStringSubString(const char *a, const char *b);
 
 /**
  * Initializes the buffer.
@@ -234,8 +234,8 @@ EXTERNAL fiftyoneDegreesStringBuilder* fiftyoneDegreesStringBuilderAddInteger(
  */
 EXTERNAL fiftyoneDegreesStringBuilder* fiftyoneDegreesStringBuilderAddChars(
 	fiftyoneDegreesStringBuilder* builder,
-	char* const value,
-	size_t const length);
+	const char* value,
+	size_t length);
 
 /**
  * Adds a null terminating character to the buffer.


### PR DESCRIPTION
### Changes

- `StringBuilderAddChars` now accepts ***const*** `char *`
- `StringSubString` now returns ***const*** `char *`

### Why

> passing argument 2 of 'fiftyoneDegreesStringBuilderAddChars' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]

^ if passing ***const*** `char *` into `StringBuilderAddChars`