### PR TITLE
Collection: fix C++20 warning

### DIFF
--- a/Collection.hpp
+++ b/Collection.hpp
@@ -86,7 +86,7 @@ namespace FiftyoneDegrees {
 			/**
 			 * Dispose of any internal data.
 			 */
-			virtual ~Collection<K, V>() {};
+			virtual ~Collection() {};
 
 			/**
 			 * @}
@@ -123,7 +123,7 @@ namespace FiftyoneDegrees {
 			/**
 			 * A collection can't be constructed without an inheriting class.
 			 */
-			Collection<K, V>() { }
+			Collection() { }
 		};
 	}
 }


### PR DESCRIPTION
Newer GCC versions return the following warning for the changed lines:

```
error: template-id not allowed for destructor in C++20 [-Werror=template-id-cdtor]
note: remove the ‘< >’
```

This applies compiler's recommendation.