### PR TITLE
Revert "REFACT: Make `IpAddressParse` non-allocating."

### DIFF
--- a/IpAddress.cpp
+++ b/IpAddress.cpp
@@ -43,18 +43,20 @@ FiftyoneDegrees::IpIntelligence::IpAddress::IpAddress(
 
 FiftyoneDegrees::IpIntelligence::IpAddress::IpAddress(
     const char * const ipAddressString) {
-    ::IpAddress eIpAddress;
-    const bool parsed =
+    ::IpAddress *eIpAddress =
 		IpAddressParse(
+			Malloc,
 			ipAddressString,
-			ipAddressString + strlen(ipAddressString),
-			&eIpAddress);
+			ipAddressString + strlen(ipAddressString));
     // Make sure the ip address has been parsed successfully
-	if (!parsed) {
+	if (eIpAddress == nullptr) {
 		throw bad_alloc();
 	}
     // Initialize the IP address object
-    init(eIpAddress.value, static_cast<IpType>(eIpAddress.type));
+    init(eIpAddress->value, static_cast<IpType>(eIpAddress->type));
+
+    // Free the previously allocated IP address
+    Free(eIpAddress);
 }
 
 void FiftyoneDegrees::IpIntelligence::IpAddress::init(

--- a/ip.c
+++ b/ip.c
@@ -262,17 +262,18 @@ static IpType iterateIpAddress(
 	return type;
 }
 
-bool fiftyoneDegreesIpAddressParse(
+IpAddress* fiftyoneDegreesIpAddressParse(
+	void*(* const malloc)(size_t),
 	const char * const start,
-	const char * const end,
-	IpAddress * const address) {
+	const char * const end) {
 
 	if (!start) {
-		return false;
+		return NULL;
 	}
 
 	int byteCount = 0;
 	int springCount = 0;
+	IpAddress *address;
 	IpType type = iterateIpAddress(
 		start,
 		end,
@@ -284,35 +285,38 @@ bool fiftyoneDegreesIpAddressParse(
 	switch (type) {
 		case IP_TYPE_IPV4:
 			if (byteCount != IPV4_LENGTH || springCount) {
-				return false;
+				return NULL;
 			}
 			break;
 		case IP_TYPE_IPV6:
 			if (byteCount > IPV6_LENGTH ||
 				springCount > 1 ||
 				(byteCount < IPV6_LENGTH && !springCount)) {
-				return false;
+				return NULL;
 			}
 			break;
 		default:
-			return false;
+			return NULL;
 	}
 
-	address->type = type;
-	IpAddressBuildState buildState = {
-		address,
-		address->value,
-		byteCount,
-	};
-	// Add the bytes from the source value and get the type of address.
-	iterateIpAddress(
-		start,
-		end,
-		&buildState,
-		&springCount,
-		type,
-		callbackIpAddressBuild);
-	return true;
+	address = malloc(sizeof(IpAddress));
+	if (address != NULL) {
+		address->type = type;
+		IpAddressBuildState buildState = {
+			address,
+			address->value,
+			byteCount,
+		};
+		// Add the bytes from the source value and get the type of address.
+		iterateIpAddress(
+			start,
+			end,
+			&buildState,
+			&springCount,
+			type,
+			callbackIpAddressBuild);
+	}
+	return address;
 }
 
 int fiftyoneDegreesIpAddressesCompare(

--- a/ip.h
+++ b/ip.h
@@ -74,15 +74,15 @@ typedef struct fiftyone_degrees_ip_address_t {
 
 /**
  * Parse a single IP address string.
+ * @param malloc method to allocate the IP address
  * @param start of the string containing the IP address to parse
  * @param end of the string containing the IP address to parse
- * @param address memory to write parsed IP address into
- * @return <c>true</c> if address was parsed correctly, <c>false</c> otherwise
+ * @return pointer to the parsed IP address
  */
-EXTERNAL bool fiftyoneDegreesIpAddressParse(
-	const char * const start,
-	const char * const end,
-	fiftyoneDegreesIpAddress * const address);
+EXTERNAL fiftyoneDegreesIpAddress* fiftyoneDegreesIpAddressParse(
+	void*(*malloc)(size_t),
+	const char *start,
+	const char *end);
 
 /**
  * Compare two IP addresses in its binary form

--- a/value.c
+++ b/value.c
@@ -84,15 +84,15 @@ static int compareCoordinate(String *value, const char *target) {
  */
 static int compareIpAddress(String *value, const char *target) {
 	int result = 0;
-	IpAddress ipAddress;
-	bool parsed = IpAddressParse(
+	IpAddress *ipAddress
+		= IpAddressParse(
+			Malloc, 
 			target, 
-			target + strlen(target),
-			&ipAddress);
-	if (parsed) {
+			target + strlen(target));
+	if (ipAddress != NULL) {
 		int16_t valueLength = (size_t)value->size - 1;
 		int16_t searchLength = 0, compareLength = 0;
-		switch (ipAddress.type) {
+		switch (ipAddress->type) {
 		case IP_TYPE_IPV4:
 			searchLength = IPV4_LENGTH;
 			break;
@@ -112,11 +112,12 @@ static int compareIpAddress(String *value, const char *target) {
 			compareLength = (valueLength < searchLength
 				? valueLength : searchLength);
 			result = memcmp(&value->trail.secondValue,
-				ipAddress.value, compareLength);
+				ipAddress->value, compareLength);
 			if (result == 0) {
 				result = valueLength - searchLength;
 			}
 		}
+		Free(ipAddress);
 	}
 	return result;
 }


### PR DESCRIPTION
Reverts 51Degrees/common-cxx#80.   Not sure we need to necessarily revert this one, but maybe just fix the comment - the exception it throws. 