### PR TITLE
FEAT: Improve flexibility of common library props to support dynamic as well as static libraries.

### DIFF
--- a/VisualStudio/Library.Build.props
+++ b/VisualStudio/Library.Build.props
@@ -62,7 +62,8 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType Condition="'$(ConfigurationType)' != ''">$(ConfigurationType)</ConfigurationType>
+    <ConfigurationType Condition="'$(ConfigurationType)' == ''">StaticLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <IntDir>$(ProjectDir)Intermediate\$(Platform)\$(Configuration)\</IntDir>


### PR DESCRIPTION
Where the library is to be output as an assembly for dynamic rather than static linking it should be possible in vcxproj files to include this setting and override the value in the props file. However this doesn't seem to be working. Thus to include the feature a variable is added called ConfigurationType that can be used to override the value in the common library.