### PR TITLE
IP parsing function contract improvements.

### DIFF
--- a/ip.c
+++ b/ip.c
@@ -208,6 +208,8 @@ static IpType iterateIpAddress(
 	IpType type,
 	const parseIterator foundSegment) {
 
+	const char * const postEnd = end + 1;
+
 	*springCount = 0;
 	if (*start == '[') {
 		if (type == IP_TYPE_IPV4) {
@@ -221,9 +223,13 @@ static IpType iterateIpAddress(
 
 	const char *current = start;
 	const char *nextSegment = current;
-	for (; current <= end && nextSegment < end; ++current) {
+	for (; current <= postEnd && nextSegment <= postEnd; ++current) {
+		char nextChar = 0;
+		if (current < postEnd) {
+			nextChar = *current;
+		}
 		IpStringSeparatorType separatorType =
-			getSeparatorCharType(*current, type);
+			getSeparatorCharType(nextChar, type);
 		if (!separatorType) {
 			continue;
 		}
@@ -232,7 +238,7 @@ static IpType iterateIpAddress(
 		}
 
 		currentSegmentType = getSegmentTypeWithSeparator(
-			*current, type, currentSegmentType);
+			nextChar, type, currentSegmentType);
 		if (type == IP_TYPE_INVALID) {
 			type = currentSegmentType;
 		}

--- a/ip.c
+++ b/ip.c
@@ -177,6 +177,7 @@ static IpStringSeparatorType getSeparatorCharType(
 		case ']':
 		case '/':
 		case '\0':
+		case '\n':
 			return IP_ADDRESS_BREAK_CHAR;
 		default:
 			break;

--- a/ip.h
+++ b/ip.h
@@ -74,15 +74,16 @@ typedef struct fiftyone_degrees_ip_address_t {
 
 /**
  * Parse a single IP address string.
+ * Does not modify the last 12 (out of 16) bytes when parsing IPv4.
  * @param start of the string containing the IP address to parse
- * @param end of the string containing the IP address to parse
- * @param address memory to write parsed IP address into
+ * @param end the last character of the string (with IP address) to be considered for parsing
+ * @param address memory to write parsed IP address into.
  * @return <c>true</c> if address was parsed correctly, <c>false</c> otherwise
  */
 EXTERNAL bool fiftyoneDegreesIpAddressParse(
-	const char * const start,
-	const char * const end,
-	fiftyoneDegreesIpAddress * const address);
+	const char *start,
+	const char *end,
+	fiftyoneDegreesIpAddress *address);
 
 /**
  * Compare two IP addresses in its binary form

--- a/tests/IpParserTests.cpp
+++ b/tests/IpParserTests.cpp
@@ -60,6 +60,16 @@ TEST(ParseIp, ParseIp_Ipv4_High)
 	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected)))
 		<< L"Expected result to be '255.255.255.255'";
 }
+TEST(ParseIp, ParseIp_Ipv4_Endline)
+{
+	const char* ip = "0.0.0.0\n";
+	auto const result = parseIpAddressString(ip);
+	byte expected[] = { 0, 0, 0, 0 };
+	EXPECT_TRUE(result) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '0.0.0.0'";
+}
 TEST(ParseIp, ParseIp_Ipv4_PortNumber)
 {
 	auto const result = parseIpAddressString("1.2.3.4:80");

--- a/tests/IpParserTests.cpp
+++ b/tests/IpParserTests.cpp
@@ -25,7 +25,7 @@
 #include "../fiftyone.h"
 #include <memory>
 
-static bool CheckResult(byte* result, byte* expected, uint16_t size) {
+static bool CheckResult(byte* result, const byte* expected, uint16_t size) {
 	bool match = true;
 	for (uint16_t i = 0; i < size; i++) {
 		match = match && *result == *expected;
@@ -35,10 +35,14 @@ static bool CheckResult(byte* result, byte* expected, uint16_t size) {
 	return match;
 }
 
+static bool parseIpAddressInPlace(const std::unique_ptr<IpAddress> &ipAddress, const char * const ipString, const size_t length) {
+	const char * const end = ipString ? ipString + length : nullptr;
+	return IpAddressParse(ipString, end, ipAddress.get());
+}
+
 static std::unique_ptr<IpAddress> parseIpAddressStringOfLength(const char * const ipString, const size_t length) {
 	std::unique_ptr<IpAddress> ipPtr = std::make_unique<IpAddress>();
-	const char * const end = ipString ? ipString + length : nullptr;
-	const bool parsed = IpAddressParse(ipString, end, ipPtr.get());
+	const bool parsed =parseIpAddressInPlace(ipPtr, ipString, length);
 	return parsed ? std::move(ipPtr) : nullptr;
 }
 
@@ -73,6 +77,22 @@ TEST(ParseIp, ParseIp_Ipv4_Endline)
 		L"Expected result to be non-NULL.";
 	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
 		L"Expected result to be '0.0.0.0'";
+}
+TEST(ParseIp, ParseIp_Ipv4_NoOverwrite12)
+{
+	const char ip[] = "73.79.83.89";
+	constexpr byte initial[] {
+		67, 13, 43, 47, 53, 29, 61, 19, 41, 31, 59, 71, 23, 37, 17, 11,
+	}, expected[] {
+		73, 79, 83, 89, 53, 29, 61, 19, 41, 31, 59, 71, 23, 37, 17, 11,
+	};
+	std::unique_ptr<IpAddress> ipAddress = std::make_unique<IpAddress>();
+	memcpy(ipAddress->value, initial, sizeof(initial));
+	const bool parsed = parseIpAddressInPlace(ipAddress, ip, sizeof(ip));
+	EXPECT_TRUE(parsed) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(ipAddress->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '73.79.83.89' with the rest (12 bytes) unchanged.";
 }
 TEST(ParseIp, ParseIp_Ipv4_Trim0)
 {

--- a/tests/IpParserTests.cpp
+++ b/tests/IpParserTests.cpp
@@ -35,11 +35,15 @@ static bool CheckResult(byte* result, byte* expected, uint16_t size) {
 	return match;
 }
 
-static std::unique_ptr<IpAddress> parseIpAddressString(const char * const ipString) {
+static std::unique_ptr<IpAddress> parseIpAddressStringOfLength(const char * const ipString, const size_t length) {
 	std::unique_ptr<IpAddress> ipPtr = std::make_unique<IpAddress>();
-	const char * const end = ipString ? ipString + strlen(ipString) : nullptr;
+	const char * const end = ipString ? ipString + length : nullptr;
 	const bool parsed = IpAddressParse(ipString, end, ipPtr.get());
 	return parsed ? std::move(ipPtr) : nullptr;
+}
+
+static std::unique_ptr<IpAddress> parseIpAddressString(const char * const ipString) {
+	return parseIpAddressStringOfLength(ipString, ipString ? strlen(ipString) : 0);
 }
 
  // ------------------------------------------------------------------------------
@@ -69,6 +73,46 @@ TEST(ParseIp, ParseIp_Ipv4_Endline)
 		L"Expected result to be non-NULL.";
 	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
 		L"Expected result to be '0.0.0.0'";
+}
+TEST(ParseIp, ParseIp_Ipv4_Trim0)
+{
+	const char* ip = "192.168.101.217";
+	auto const result = parseIpAddressStringOfLength(ip, strlen(ip));
+	byte expected[] = { 192, 168, 101, 217 };
+	EXPECT_TRUE(result) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '192.168.101.217'";
+}
+TEST(ParseIp, ParseIp_Ipv4_Trim1)
+{
+	const char* ip = "192.168.101.217";
+	auto const result = parseIpAddressStringOfLength(ip, strlen(ip) - 1);
+	byte expected[] = { 192, 168, 101, 217 };
+	EXPECT_TRUE(result) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '192.168.101.217'";
+}
+TEST(ParseIp, ParseIp_Ipv4_Trim2)
+{
+	const char* ip = "192.168.101.217";
+	auto const result = parseIpAddressStringOfLength(ip, strlen(ip) - 2);
+	byte expected[] = { 192, 168, 101, 21 };
+	EXPECT_TRUE(result) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '192.168.101.21'";
+}
+TEST(ParseIp, ParseIp_Ipv4_Trim3)
+{
+	const char* ip = "192.168.101.217";
+	auto const result = parseIpAddressStringOfLength(ip, strlen(ip) - 3);
+	byte expected[] = { 192, 168, 101, 2 };
+	EXPECT_TRUE(result) <<
+		L"Expected result to be non-NULL.";
+	EXPECT_TRUE(CheckResult(result->value, expected, sizeof(expected) - 1)) <<
+		L"Expected result to be '192.168.101.2'";
 }
 TEST(ParseIp, ParseIp_Ipv4_PortNumber)
 {


### PR DESCRIPTION
### Changes

- Treat the new line character (`\n`) as a valid terminator of IP address.
- Expect `end` parameter to point to (not past) the last character of IP address.
- Allow the last character to not be a terminator (but e.g. an actual 'digit').
- Add tests for all the above.
- Verify (add a test) that parsing IPv4 does not overwrite unused bytes (12/16).
- Update a comment to clarify the behavior.

### Test runs

- ✅ https://github.com/postindustria-tech/common-cxx/actions/runs/13495898953