### PR TITLE
Generalize profile iterate method to not depend on offset struct layout.

### DIFF
--- a/fiftyone.h
+++ b/fiftyone.h
@@ -206,6 +206,10 @@ MAP_TYPE(WkbtotReductionMode)
 #define ProfileIterateValuesForPropertyWithIndex fiftyoneDegreesProfileIterateValuesForPropertyWithIndex /**< Synonym for #fiftyoneDegreesProfileIterateValuesForPropertyWithIndex function. */
 #define ProfileIterateValueIndexes fiftyoneDegreesProfileIterateValueIndexes /**< Synonym for #fiftyoneDegreesProfileIterateValueIndexes function. */
 #define ProfileIterateProfilesForPropertyAndValue fiftyoneDegreesProfileIterateProfilesForPropertyAndValue /**< Synonym for #fiftyoneDegreesProfileIterateProfilesForPropertyAndValue function. */
+#define ProfileIterateProfilesForPropertyWithTypeAndValue fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue /**< Synonym for #fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue function. */
+#define ProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor /**< Synonym for #fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor function. */
+#define ProfileOffsetAsPureOffset fiftyoneDegreesProfileOffsetAsPureOffset /**< Synonym for #fiftyoneDegreesProfileOffsetAsPureOffset function. */
+#define ProfileOffsetToPureOffset fiftyoneDegreesProfileOffsetToPureOffset /**< Synonym for #fiftyoneDegreesProfileOffsetToPureOffset function. */
 #define PropertiesGetPropertyIndexFromName fiftyoneDegreesPropertiesGetPropertyIndexFromName /**< Synonym for #fiftyoneDegreesPropertiesGetPropertyIndexFromName function. */
 #define TreeIterate fiftyoneDegreesTreeIterateNodes /**< Synonym for #fiftyoneDegreesTreeIterateNodes function. */
 #define TreeCount fiftyoneDegreesTreeCount /**< Synonym for #fiftyoneDegreesTreeCount function. */

--- a/profile.c
+++ b/profile.c
@@ -426,24 +426,58 @@ uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyAndValue(
 		exception);
 }
 
+uint32_t fiftyoneDegreesProfileOffsetToPureOffset(const void * const rawProfileOffset) {
+	return ((const ProfileOffset*)rawProfileOffset)->offset;
+}
+uint32_t fiftyoneDegreesProfileOffsetAsPureOffset(const void * const rawProfileOffset) {
+	return *(const uint32_t*)rawProfileOffset;
+}
+
 uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue(
-	fiftyoneDegreesCollection *strings,
-	fiftyoneDegreesCollection *properties,
-	fiftyoneDegreesCollection *propertyTypes,
-	fiftyoneDegreesCollection *values,
-	fiftyoneDegreesCollection *profiles,
-	fiftyoneDegreesCollection *profileOffsets,
-	const char *propertyName,
-	const char* valueName,
-	void *state,
-	fiftyoneDegreesProfileIterateMethod callback,
-	fiftyoneDegreesException *exception) {
+	fiftyoneDegreesCollection * const strings,
+	fiftyoneDegreesCollection * const properties,
+	fiftyoneDegreesCollection * const propertyTypes,
+	fiftyoneDegreesCollection * const values,
+	fiftyoneDegreesCollection * const profiles,
+	fiftyoneDegreesCollection * const profileOffsets,
+	const char * const propertyName,
+	const char * const valueName,
+	void * const state,
+	const fiftyoneDegreesProfileIterateMethod callback,
+	fiftyoneDegreesException * const exception) {
+	return ProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor(
+		strings,
+		properties,
+		propertyTypes,
+		values,
+		profiles,
+		profileOffsets,
+		ProfileOffsetToPureOffset,
+		propertyName,
+		valueName,
+		state,
+		callback,
+		exception);
+}
+
+uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor(
+	fiftyoneDegreesCollection * const strings,
+	fiftyoneDegreesCollection * const properties,
+	fiftyoneDegreesCollection * const propertyTypes,
+	fiftyoneDegreesCollection * const values,
+	fiftyoneDegreesCollection * const profiles,
+	fiftyoneDegreesCollection * const profileOffsets,
+	const fiftyoneDegreesProfileOffsetValueExtractor offsetValueExtractor,
+	const char * const propertyName,
+	const char * const valueName,
+	void *const state,
+	const fiftyoneDegreesProfileIterateMethod callback,
+	fiftyoneDegreesException * const exception) {
 	uint32_t i, count = 0;
 	Item propertyItem, offsetItem, profileItem;
 	uint32_t *profileValueIndex, *maxProfileValueIndex;
 	Property *property;
 	Profile *profile;
-	ProfileOffset *profileOffset;
 	DataReset(&propertyItem.data);
 	property = PropertyGetByName(
 		properties, 
@@ -475,15 +509,16 @@ uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue(
 			DataReset(&profileItem.data);
 			uint32_t profileOffsetsCount = CollectionGetCount(profileOffsets);
 			for (i = 0; i < profileOffsetsCount; i++) {
-				profileOffset = (ProfileOffset*)profileOffsets->get(
+				const void * const rawProfileOffset = profileOffsets->get(
 					profileOffsets,
 					i,
 					&offsetItem, 
 					exception);
-				if (profileOffset != NULL && EXCEPTION_OKAY) {
+				if (rawProfileOffset != NULL && EXCEPTION_OKAY) {
+					const uint32_t pureProfileOffset = offsetValueExtractor(rawProfileOffset);
 					profile = getProfileByOffset(
 						profiles,
-						profileOffset->offset,
+						pureProfileOffset,
 						&profileItem,
 						exception);
 					if (profile != NULL && EXCEPTION_OKAY) {

--- a/profile.h
+++ b/profile.h
@@ -108,6 +108,31 @@ typedef struct fiftyoneDegrees_profile_offset_t {
 #pragma pack(pop)
 
 /**
+ * Function that extracts "pure" profile offset
+ * from a value inside `profileOffsets` collection
+ * @param rawProfileOffset a "raw" value retrieved from `profileOffsets`
+ * @return Offset to the profile in the profiles structure
+ */
+typedef uint32_t (*fiftyoneDegreesProfileOffsetValueExtractor)(const void *rawProfileOffset);
+
+/**
+ * Function that extracts "pure" profile offset
+ * from a fiftyoneDegreesProfileOffset.
+ * @param rawProfileOffset a "raw" ProfileOffset retrieved from `profileOffsets`
+ * @return Offset to the profile in the profiles structure
+ */
+uint32_t fiftyoneDegreesProfileOffsetToPureOffset(const void *rawProfileOffset);
+
+/**
+ * Function that extracts "pure" profile offset
+ * from a value (that starts with a "pure" profile offset)
+ * inside `profileOffsets` collection
+ * @param rawProfileOffset a "raw" value retrieved from `profileOffsets`
+ * @return Offset to the profile in the profiles structure
+ */
+uint32_t fiftyoneDegreesProfileOffsetAsPureOffset(const void *rawProfileOffset);
+
+/**
  * Definition of a callback function which is passed an item of a type 
  * determined by the iteration method.
  * @param state pointer to data needed by the method
@@ -242,7 +267,7 @@ EXTERNAL uint32_t fiftyoneDegreesProfileIterateValuesForPropertyWithIndex(
  * @param values collection containing all values
  * @param profiles collection containing the profiles referenced by the profile
  * offsets
- * @param profileOffsets collection containing all profile offsets
+ * @param profileOffsets collection containing all profile offsets (with IDs)
  * @param propertyName name of the property the value relates to
  * @param valueName name of the value to iterate the profiles for
  * @param state pointer to data needed by the callback method
@@ -258,6 +283,40 @@ EXTERNAL uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndVal
 	fiftyoneDegreesCollection *values,
 	fiftyoneDegreesCollection *profiles,
 	fiftyoneDegreesCollection *profileOffsets,
+	const char *propertyName,
+	const char* valueName,
+	void *state,
+	fiftyoneDegreesProfileIterateMethod callback,
+	fiftyoneDegreesException *exception);
+
+/**
+ * Iterate all profiles which contain the specified value, calling the callback
+ * method for each.
+ * @param strings collection containing the strings referenced properties and
+ * values
+ * @param properties collection containing all properties
+ * @param propertyTypes collection containing types for all properties
+ * @param values collection containing all values
+ * @param profiles collection containing the profiles referenced by the profile
+ * offsets
+ * @param profileOffsets collection containing all profile offsets (any form)
+ * @param offsetValueExtractor converts `profileOffsets` value to "pure" offset
+ * @param propertyName name of the property the value relates to
+ * @param valueName name of the value to iterate the profiles for
+ * @param state pointer to data needed by the callback method
+ * @param callback method to be called for each matching profile
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h
+ * @return the number matching profiles which have been iterated
+ */
+EXTERNAL uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor(
+	fiftyoneDegreesCollection *strings,
+	fiftyoneDegreesCollection *properties,
+	fiftyoneDegreesCollection *propertyTypes,
+	fiftyoneDegreesCollection *values,
+	fiftyoneDegreesCollection *profiles,
+	fiftyoneDegreesCollection *profileOffsets,
+	fiftyoneDegreesProfileOffsetValueExtractor offsetValueExtractor,
 	const char *propertyName,
 	const char* valueName,
 	void *state,


### PR DESCRIPTION
### Changes

- Generalize profile iterate method to not depend on offset struct layout.

### Why

- https://github.com/51Degrees/ip-intelligence-cxx/issues/27