### PR TITLE
Collection offset tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,8 @@ target_link_libraries(fiftyone-common-cxx fiftyone-common-c)
 
 set_target_properties(fiftyone-common-c fiftyone-common-cxx	PROPERTIES FOLDER "Common")
 if (LargeDataFileSupport)
-	# public -- expose to dependees.
-	target_compile_definitions(fiftyone-common-c PUBLIC FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT)
+	# global -- to propagate through whole build graph, including tests
+	add_compile_definitions(FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT)
 	# global -- in case sibling lib uses stdio as well.
 	add_compile_definitions(_FILE_OFFSET_BITS=64)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,13 @@ if(FIFTYONE_COMMON_CXX_BUILD_TESTING)
 		target_link_libraries(CommonTests fiftyone-common-cxx gtest_main)
 	endif()
 
+	if (LargeDataFileSupport)
+		# global -- to propagate through whole build graph, including tests
+		add_compile_definitions(FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT)
+		# global -- in case sibling lib uses stdio as well.
+		add_compile_definitions(_FILE_OFFSET_BITS=64)
+	endif ()
+
 	gtest_discover_tests(CommonTests PROPERTIES TEST_DISCOVERY_TIMEOUT 600 DISCOVERY_MODE PRE_TEST)
 	set_target_properties(CommonTests PROPERTIES FOLDER "Tests") 
 

--- a/VisualStudio/Fiftyone.Common.Tests/Fiftyone.Common.Tests.vcxproj
+++ b/VisualStudio/Fiftyone.Common.Tests/Fiftyone.Common.Tests.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="..\..\tests\Base.cpp" />
     <ClCompile Include="..\..\tests\CacheTests.cpp" />
     <ClCompile Include="..\..\tests\CollectionConfigTests.cpp" />
+    <ClCompile Include="..\..\tests\CollectionOffsetTests.cpp" />
     <ClCompile Include="..\..\tests\CollectionTests.cpp" />
     <ClCompile Include="..\..\tests\EngineTests.cpp" />
     <ClCompile Include="..\..\tests\EvidenceTests.cpp" />
@@ -68,6 +69,7 @@
     <ClInclude Include="..\..\tests\StringCollection.hpp" />
     <ClInclude Include="..\..\tests\TestStrings.hpp" />
     <ClInclude Include="..\..\tests\FixedSizeCollection.hpp" />
+    <ClInclude Include="..\..\tests\TestUtils_Pointers.hpp" />
     <ClInclude Include="..\..\tests\VariableSizeCollection.hpp" />
     <ClInclude Include="..\..\tests\HeadersContainer.hpp" />
   </ItemGroup>

--- a/VisualStudio/Fiftyone.Common.Tests/Fiftyone.Common.Tests.vcxproj.filters
+++ b/VisualStudio/Fiftyone.Common.Tests/Fiftyone.Common.Tests.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="..\..\tests\StoredBinaryValueTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\tests\CollectionOffsetTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\tests\Base.hpp">
@@ -165,6 +168,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\tests\VariableSizeCollection.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\tests\TestUtils_Pointers.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/CollectionOffsetTests.cpp
+++ b/tests/CollectionOffsetTests.cpp
@@ -1,0 +1,130 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#include <gtest/gtest.h>
+#include <gtest/gtest-param-test.h>
+#include "TestUtils_Pointers.hpp"
+
+using BytesPtr = std::unique_ptr<byte[]>;
+static constexpr size_t elementsCount = 131;
+
+class CollectionOffsetTest: public testing::TestWithParam<FileOffsetUnsigned> {
+public:
+    BytesPtr bytes;
+    byte *memoryStart = nullptr;
+    byte *collectionStart = nullptr;
+    CollectionPtr collection { nullptr, freeCollection };
+
+    void rebuildCollection(FileOffsetUnsigned offset);
+};
+
+void CollectionOffsetTest::rebuildCollection(const FileOffsetUnsigned offset) {
+    const size_t fullSize = (size_t)(offset + elementsCount);
+
+    const CollectionHeader header = {
+        offset, // startPosition
+        elementsCount, // length
+        elementsCount, // count
+    };
+    bytes = std::make_unique<byte[]>(fullSize);
+    memoryStart = (byte *)bytes.get();
+    collectionStart = memoryStart + offset;
+
+
+    MemoryReader reader = {
+        memoryStart, // startByte
+        collectionStart, // current
+        memoryStart + fullSize, // lastByte
+        (FileOffset)fullSize, // length
+    };
+    fiftyoneDegreesCollection * const rawCollection = CollectionCreateFromMemory(
+        &reader,
+        header);
+    this->collection = CollectionPtr(rawCollection, freeCollection);
+}
+
+TEST_P(CollectionOffsetTest, DirectWrite) {
+    EXCEPTION_CREATE;
+    const FileOffsetUnsigned offset = GetParam();
+    rebuildCollection(offset);
+
+    for (size_t i = 0; i < elementsCount; i++) {
+        // prepare
+        ItemBox item;
+        auto const ptr = (const byte *)collection->get(
+            collection.get(),
+            (uint32_t)i,
+            *item,
+            exception);
+
+        // set
+        const byte x = (2 * i) % 255;
+        collectionStart[i] = x;
+
+        // check
+        EXPECT_EQ(x, *ptr);
+    }
+}
+
+TEST_P(CollectionOffsetTest, DirectRead) {
+    EXCEPTION_CREATE;
+    const FileOffsetUnsigned offset = GetParam();
+    rebuildCollection(offset);
+
+    for (size_t i = 0; i < elementsCount; i++) {
+        // prepare
+        ItemBox item;
+        auto const ptr = (byte *)collection->get(
+            collection.get(),
+            (uint32_t)i,
+            *item,
+            exception);
+
+        // set
+        const byte x = (2 * i) % 255;
+        *ptr = x;
+
+        // check
+        EXPECT_EQ(x, collectionStart[i]);
+    }
+}
+
+static constexpr FileOffsetUnsigned testOffsets[] = {
+    0,
+    UINT16_MAX,
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+    UINT32_MAX,
+#endif
+};
+
+
+// VS doesn't see `INSTANTIATE_TEST_SUITE_P`
+// -> https://developercommunity.visualstudio.com/t/INSTANTIATE_TEST_SUITE_P-function-defini/10409205?space=21&entry=problem&sort=newest
+#if !defined(INSTANTIATE_TEST_SUITE_P) && defined(INSTANTIATE_TEST_CASE_P)
+#   define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
+
+
+INSTANTIATE_TEST_SUITE_P(
+    CollectionOffsetTests,
+    CollectionOffsetTest,
+    testing::ValuesIn(testOffsets));

--- a/tests/CollectionOffsetTests.cpp
+++ b/tests/CollectionOffsetTests.cpp
@@ -111,8 +111,10 @@ TEST_P(CollectionOffsetTest, DirectRead) {
 static constexpr FileOffsetUnsigned testOffsets[] = {
     0,
     UINT16_MAX,
+    UINT16_MAX + 5,
 #ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
     UINT32_MAX,
+    UINT32_MAX + 7,
 #endif
 };
 

--- a/tests/StoredBinaryValueTests.cpp
+++ b/tests/StoredBinaryValueTests.cpp
@@ -23,13 +23,8 @@
 #include "../fiftyone.h"
 #include "../string.h"
 #include "Base.hpp"
+#include "TestUtils_Pointers.hpp"
 
-static void freeCollection(fiftyoneDegreesCollection * const ptr) {
-    if (ptr) {
-        ptr->freeCollection(ptr);
-    }
-}
-using CollectionPtr = std::unique_ptr<fiftyoneDegreesCollection, decltype(&freeCollection)>;
 static void releaseFilePool(FilePool * const ptr) {
     if (ptr) {
         FilePoolRelease(ptr);
@@ -197,28 +192,6 @@ void StoredBinaryValues::SetUp() {
 
 void StoredBinaryValues::TearDown() {
 }
-
-static void releaseItem(Item * const item) {
-    if (item) {
-        COLLECTION_RELEASE(item->collection, item);
-    }
-}
-using ItemPtr = std::unique_ptr<Item, decltype(&releaseItem)>;
-
-class ItemBox {
-    Item item = {};
-public:
-    ItemBox() {
-        DataReset(&item.data);
-    }
-    ~ItemBox() {
-        if (item.collection) {
-            COLLECTION_RELEASE(item.collection, &item);
-        }
-    }
-    Item *operator*() { return &item; }
-    Item *operator->() { return &item; }
-};
 
 
 // ============== StoredBinaryValueGet (from memory) ==============

--- a/tests/TestUtils_Pointers.hpp
+++ b/tests/TestUtils_Pointers.hpp
@@ -1,0 +1,59 @@
+/* *********************************************************************
+* This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#ifndef TESTUTILS_POINTERS_HPP
+#define TESTUTILS_POINTERS_HPP
+
+#include "../fiftyone.h"
+#include <memory>
+
+static void freeCollection(fiftyoneDegreesCollection * const ptr) {
+    if (ptr) {
+        ptr->freeCollection(ptr);
+    }
+}
+using CollectionPtr = std::unique_ptr<fiftyoneDegreesCollection, decltype(&freeCollection)>;
+
+
+static void releaseItem(Item * const item) {
+    if (item) {
+        COLLECTION_RELEASE(item->collection, item);
+    }
+}
+using ItemPtr = std::unique_ptr<Item, decltype(&releaseItem)>;
+
+class ItemBox {
+    Item item = {};
+public:
+    ItemBox() {
+        DataReset(&item.data);
+    }
+    ~ItemBox() {
+        if (item.collection) {
+            COLLECTION_RELEASE(item.collection, &item);
+        }
+    }
+    Item *operator*() { return &item; }
+    Item *operator->() { return &item; }
+};
+
+#endif //TESTUTILS_POINTERS_HPP


### PR DESCRIPTION
### Changes

- Add `CollectionOffsetTest.cpp`
- Move shared smart pointer and box types from `StoredBinaryValueTests.cpp` to `TestUtils_Pointers.hpp`
- Use `add_compile_definitions` for `FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT` in CMakeFile

### Why

- https://github.com/51Degrees/common-cxx/issues/109