### PR TITLE
IP Address SWIG Java fixes

### DIFF
--- a/IpAddress.i
+++ b/IpAddress.i
@@ -1,4 +1,4 @@
-%include "common-cxx/ip.i"
+%include "ip.i"
 
 %nodefaultctor IpAddress;
 

--- a/IpAddress.i
+++ b/IpAddress.i
@@ -4,6 +4,13 @@
 
 %rename (IpAddressSwig) IpAddress;
 
+#ifdef SWIGJAVA
+%include "JavaTypes.i"
+
+%apply (unsigned char *UCHAR, fiftyoneDegreesIpType type) {(unsigned char ipAddress[], fiftyoneDegreesIpType type)}
+%apply (unsigned char *UCHAR, uint32_t UINT32) {(unsigned char copy[], uint32_t size)}
+#endif
+
 class IpAddress {
 public:
     IpAddress(const unsigned char ipAddress[], fiftyoneDegreesIpType type);

--- a/JavaTypes.i
+++ b/JavaTypes.i
@@ -74,7 +74,6 @@
 /* Prevent default freearg typemap from being used */
 %typemap(freearg) (unsigned char *UCHAR) ""
 
-%apply (unsigned char *UCHAR) { (unsigned char copy[]) };
 %apply (unsigned char *UCHAR) { (unsigned char data[]) };
 %apply (unsigned char *UCHAR) { (unsigned char ipAddress[]) };
 

--- a/ip.h
+++ b/ip.h
@@ -56,7 +56,7 @@
 /**
  * Enum indicating the type of IP address.
  */
-typedef enum e_fiftyone_degrees_ip_evidence_type {
+typedef enum e_fiftyone_degrees_ip_type {
 	FIFTYONE_DEGREES_IP_TYPE_INVALID = 0, /**< Invalid IP address */
 	FIFTYONE_DEGREES_IP_TYPE_IPV4 = 4, /**< An IPv4 address */
 	FIFTYONE_DEGREES_IP_TYPE_IPV6 = 6, /**< An IPv6 address */


### PR DESCRIPTION
### Changes

- Make a `JAVA_UBYTE_ARR_TYPEMAP_BODY` define with a body of `%typemap(in) (unsigned char *UCHAR, long LONG)`
- Make a `JAVA_UBYTE_ARR_DECL(CTYPE, CTYPEVAR)` define with typemaps for length parameter.
- Use new defines to expand ubyte-ptr typemap coverage
  - was `(unsigned char *UCHAR, long LONG)`
  - added `(unsigned char *UCHAR, uint32_t UINT32)`
  - added `(unsigned char *UCHAR)`

### Related

- Reverts #112 
- Expands on #68