### PR TITLE
BUG/TEST: The case of a negative double less than 1 is now handled when converting WKB to string, and a test added.

### DIFF
--- a/stringBuilder.c
+++ b/stringBuilder.c
@@ -139,7 +139,7 @@ StringBuilder* fiftyoneDegreesStringBuilderAddDouble(
 	fiftyoneDegreesStringBuilder * const builder,
 	const double value,
 	const uint8_t decimalPlaces) {
-
+	bool addNegative = FALSE;
 	const int digitPlaces = MAX_DOUBLE_DECIMAL_PLACES < decimalPlaces
 		? MAX_DOUBLE_DECIMAL_PLACES : decimalPlaces;
 	int remDigits = digitPlaces;
@@ -148,6 +148,12 @@ StringBuilder* fiftyoneDegreesStringBuilderAddDouble(
 	double fracPart = value - intPart;
 
 	if (fracPart < 0) {
+		if (intPart == 0) {
+			// Handle negative numbers <1. The integer part will just be zero,
+			// which is neither positive or negative. So the negative must be
+			// added.
+			addNegative = TRUE;
+		}
 		fracPart = -fracPart;
 	}
 	if (remDigits <= 0 && fracPart >= 0.5) {
@@ -208,7 +214,9 @@ StringBuilder* fiftyoneDegreesStringBuilderAddDouble(
 	for (; nextDigit >= digits; --nextDigit) {
 		*nextDigit += '0';
 	}
-
+	if (addNegative) {
+		StringBuilderAddChar(builder, '-');
+	}
 	StringBuilderAddInteger(builder, intPart);
 	StringBuilderAddChars(builder, floatTail, digitsToAdd + 1);
 	return builder;

--- a/tests/WellKnownBinaryToTextTests.cpp
+++ b/tests/WellKnownBinaryToTextTests.cpp
@@ -141,6 +141,19 @@ TEST(WKBToT, WKBToT_Test_Point_2D_XDR)
 	convertAndCompare(wkbBytes, expected, "Point 2D (XDR)");
 }
 
+TEST(WKBToT, WKBToT_Test_Point_NegativeZero)
+{
+	const byte wkbBytes[] = {
+		0x01,
+		0x01, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xbf,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x31, 0x40,
+	};
+	const char * const expected = "POINT(-0.5 17.25)";
+
+	convertAndCompare(wkbBytes, expected, "Point 2D (Negative < 1)");
+}
+
 TEST(WKBToT, WKBToT_Test_Point_2D_3places)
 {
 	const byte wkbBytes[] = {


### PR DESCRIPTION
Previously, the int part would have no sign (as it was zero), but the negative was removed from the decimal part.