### PR TITLE
Introduce `CollectionKey` struct. pt.2

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -432,79 +432,51 @@ static Collection* createFromFile(
 	return collection;
 }
 
+#endif
+
 static Collection* createFromFileToMemory(
 	FILE *file,
-	FilePool *reader,
-	CollectionHeader *header,
-	CollectionFileRead read) {
+	CollectionHeader header) {
 	EXCEPTION_CREATE;
+	byte * const data = (byte*)Malloc(header.length * sizeof(byte));
+	MemoryReader memory;
 
-	// Create a file collection to populate the memory collection.
-	Collection *source = createFromFile(file, reader, header, read);
-
-	// Allocate the memory for the collection and implementation.
-	Collection *collection = createCollection(
-		sizeof(CollectionFile),
-		header,
-		"CollectionMemory");
-	CollectionMemory *memory = (CollectionMemory*)collection->state;
-	memory->memoryToFree = NULL;
-	memory->collection = collection;
-
-	// Get the number of bytes that need to be loaded into memory.
-	memory->collection->count = header->count;
-	memory->collection->size = header->length;
-
-	// Allocate sufficient memory for the data to be stored in.
-	memory->firstByte = (byte*)Malloc(memory->collection->size);
-	if (memory->firstByte == NULL) {
-		freeMemoryCollection(collection);
-		source->freeCollection(source);
+	memory.current = data;
+	if (memory.current == NULL) {
+		Free(data);
 		return NULL;
 	}
-	memory->memoryToFree = memory->firstByte;
+
+	memory.startByte = memory.current;
+	memory.length = (FileOffset)header.length;
+	memory.lastByte = memory.current + memory.length;
 
 	// Position the file reader at the start of the collection.
-	if (FileSeek(file, header->startPosition, SEEK_SET) != 0) {
-		freeMemoryCollection(collection);
-		source->freeCollection(source);
+	if (FileSeek(file, (FileOffset)header.startPosition, SEEK_SET) != 0) {
+		free(data);
 		return NULL;
 	}
 
 	// Read the portion of the file into memory.
-	if (fread(memory->firstByte, 1, memory->collection->size, file) !=
-		memory->collection->size) {
-		freeMemoryCollection(collection);
-		source->freeCollection(source);
+	if (fread(memory.startByte, 1, header.length, file) != header.length) {
+		free(data);
 		return NULL;
 	}
 
-	// Set the last byte to enable checking for invalid requests.
-	memory->lastByte = memory->firstByte + memory->collection->size;
+	header.startPosition = 0;
+	Collection * const result = CollectionCreateFromMemory(&memory, header);
 
-	// Set the getter to a method that will check for another collection
-	// if the memory collection does not contain the entry.
-	if (memory->collection->elementSize != 0) {
-		collection->get = getMemoryFixed;
-		memory->collection->count = memory->collection->size /
-			memory->collection->elementSize;
+	if (result == NULL) {
+		free(data);
+		return NULL;
 	}
-	else {
-		collection->get = getMemoryVariable;
-	}
-	if (fiftyoneDegreesCollectionGetIsMemoryOnly()) {
-		collection->release = NULL;
-	}
-	else {
-		collection->release = releaseMemory;
-	}
-	collection->freeCollection = freeMemoryCollection;
 
-	// Finally free the file collection which is no longer needed.
-	source->freeCollection(source);
+	((CollectionMemory*)result->state)->memoryToFree = data;
 
-	return collection;
+	return result;
 }
+
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 
 static Collection* createFromFileCached(
 	FILE *file,
@@ -698,89 +670,33 @@ fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromFile(
 	}
 	else {
 		header.startPosition = 0;
+		header.length = header.count = 0;
 	}
 
 	return header;
 }
 
-#if defined(_MSC_VER) && defined(FIFTYONE_DEGREES_MEMORY_ONLY)
-#pragma warning (disable: 4100)
-#endif
 fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
 	FILE *file,
 	fiftyoneDegreesFilePool *reader,
 	const fiftyoneDegreesCollectionConfig *config,
 	fiftyoneDegreesCollectionHeader header,
 	fiftyoneDegreesCollectionFileRead read) {
-	Collection *result = NULL;
 
 #ifndef FIFTYONE_DEGREES_MEMORY_ONLY
-
-	if (config->loaded > 0) {
-
-		// If the collection should be partially loaded into memory set the
-		// first collection to be a memory collection with the relevant number
-		// of entries loaded.
-		result = createFromFileToMemory(
-			file,
-			reader,
-			&header,
-			read);
-
-		if (result == NULL) {
-			// The collection could not be created from file.
-			return NULL;
-		
-		}
-	} else {
-		// Create the next collection if one is needed.
-		result = createFromFileMaybeCached(file, reader, config, header, read);
+	if (!config->loaded) {
+		return createFromFileMaybeCached(file, reader, config, header, read);
 	}
-
 #else
-
-	byte *data = (byte*)Malloc(header.length * sizeof(byte));
-	MemoryReader memory;
-
-	memory.current = data;
-	if (memory.current == NULL) {
-		Free(data);
-		return NULL;
-	}
-	
-	memory.startByte = memory.current;
-	memory.length = (FileOffset)header.length;
-	memory.lastByte = memory.current + memory.length;
-
-	// Position the file reader at the start of the collection.
-	if (FileSeek(file, header.startPosition, SEEK_SET) != 0) {
-		free(data);
-		return NULL;
-	}
-
-	// Read the portion of the file into memory.
-	if (fread(memory.startByte, 1, header.length, file) != header.length) {
-		free(data);
-		return NULL;
-	}
-
-	header.startPosition = 0;
-	result = CollectionCreateFromMemory(&memory, header);
-
-	if (result == NULL) {
-		free(data);
-		return NULL;
-	}
-
-	((CollectionMemory*)result->state)->memoryToFree = data;
-
+#	ifdef _MSC_VER
+	UNREFERENCED_PARAMETER(reader);
+	UNREFERENCED_PARAMETER(config);
+	UNREFERENCED_PARAMETER(read);
+#	endif
 #endif
 
-	return result;
+	return createFromFileToMemory(file, header);
 }
-#if defined(_MSC_VER) && defined(FIFTYONE_DEGREES_MEMORY_ONLY)
-#pragma warning (default: 4100)
-#endif
 
 fiftyoneDegreesFileHandle* fiftyoneDegreesCollectionReadFilePosition(
 	const fiftyoneDegreesCollectionFile *file,

--- a/collection.c
+++ b/collection.c
@@ -453,13 +453,13 @@ static Collection* createFromFileToMemory(
 
 	// Position the file reader at the start of the collection.
 	if (FileSeek(file, (FileOffset)header.startPosition, SEEK_SET) != 0) {
-		free(data);
+		Free(data);
 		return NULL;
 	}
 
 	// Read the portion of the file into memory.
 	if (fread(memory.startByte, 1, header.length, file) != header.length) {
-		free(data);
+		Free(data);
 		return NULL;
 	}
 
@@ -467,7 +467,7 @@ static Collection* createFromFileToMemory(
 	Collection * const result = CollectionCreateFromMemory(&memory, header);
 
 	if (result == NULL) {
-		free(data);
+		Free(data);
 		return NULL;
 	}
 

--- a/collection.c
+++ b/collection.c
@@ -555,12 +555,9 @@ static Collection* createFromFileCached(
 }
 
 /**
- * Either the first collection does not contain any in memory items, or there
- * is a need for a secondary collection to be used if the first does not
- * contain any items. Returns the second collection, or NULL if there is no
- * need for one.
+ * Creates a collection, selecting between full file mode, or adding a cache.
  */
-static Collection* createFromFileSecond(
+static Collection* createFromFileMaybeCached(
 	FILE *file,
 	FilePool *reader,
 	const CollectionConfig *config,
@@ -735,14 +732,9 @@ fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
 			return NULL;
 		
 		}
-	}
-
-	if (result == NULL || (
-		(((bool)result->count) == config->loaded) &&
-		(FileOffset)result->size < (FileTell(file) - (FileOffset)header.startPosition))) {
-
+	} else {
 		// Create the next collection if one is needed.
-		result = createFromFileSecond(file, reader, config, header, read);
+		result = createFromFileMaybeCached(file, reader, config, header, read);
 	}
 
 #else

--- a/collection.c
+++ b/collection.c
@@ -866,6 +866,7 @@ void* fiftyoneDegreesCollectionReadFileFixed(
 					// The read failed so free the memory allocated and set the
 					// status code.
 					Free(data->ptr);
+					DataReset(data);
 					EXCEPTION_SET(COLLECTION_FILE_READ_FAIL);
 				}
 			}

--- a/collectionKey.h
+++ b/collectionKey.h
@@ -49,7 +49,7 @@ typedef uint32_t (*fiftyoneDegreesCollectionGetVariableSizeMethod)(
 /**
  * Location of the item within the Collection.
  */
-typedef union fiftyone_degrees_collection_intex_or_offset_t {
+typedef union fiftyone_degrees_collection_index_or_offset_t {
 	uint32_t index;  /**< index of the item in the collection. */
 	uint32_t offset;  /**< byte offset of the item from the start of collection. */
 } fiftyoneDegreesCollectionIndexOrOffset;

--- a/collectionKeyTypes.c
+++ b/collectionKeyTypes.c
@@ -22,6 +22,7 @@
 
 #include "collectionKeyTypes.h"
 
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 uint32_t fiftyoneDegreesThrowUnsupportedStoredValueType(
     const void * const initial,
     fiftyoneDegreesException * const exception) {
@@ -31,6 +32,7 @@ uint32_t fiftyoneDegreesThrowUnsupportedStoredValueType(
     FIFTYONE_DEGREES_EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_UNSUPPORTED_STORED_VALUE_TYPE);
     return 0;
 }
+#endif
 
 const fiftyoneDegreesCollectionKeyType *fiftyoneDegreesGetCollectionKeyTypeForStoredValueType(
     const fiftyoneDegreesPropertyValueType storedValueType,

--- a/collectionKeyTypes.h
+++ b/collectionKeyTypes.h
@@ -38,7 +38,8 @@
 #include "exceptions.h"
 #include "profile.h"
 
-static uint32_t getFinalByteArraySize(
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
+static uint32_t fiftyoneDegreesGetFinalByteArraySize(
     const void *initial,
     fiftyoneDegreesException * const exception) {
 #	ifdef _MSC_VER
@@ -46,11 +47,17 @@ static uint32_t getFinalByteArraySize(
 #	endif
     return (uint32_t)(sizeof(int16_t) + (*(int16_t*)initial));
 }
+#else
+#define fiftyoneDegreesGetFinalByteArraySize NULL
+#endif
 
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 EXTERNAL uint32_t fiftyoneDegreesThrowUnsupportedStoredValueType(
     const void *initial,
     fiftyoneDegreesException *exception);
-
+#else
+#define fiftyoneDegreesThrowUnsupportedStoredValueType NULL
+#endif
 
 
 static const fiftyoneDegreesCollectionKeyType CollectionKeyType_Azimuth_raw = {
@@ -86,7 +93,7 @@ static const fiftyoneDegreesCollectionKeyType * const CollectionKeyType_Integer 
 static const fiftyoneDegreesCollectionKeyType CollectionKeyType_IPAddress_raw = {
     FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_IP_ADDRESS,
     sizeof(uint16_t),
-    getFinalByteArraySize,
+    fiftyoneDegreesGetFinalByteArraySize,
 };
 static const fiftyoneDegreesCollectionKeyType * const CollectionKeyType_IPAddress = &CollectionKeyType_IPAddress_raw;
 static const fiftyoneDegreesCollectionKeyType CollectionKeyType_Float_raw = {
@@ -140,13 +147,13 @@ static const fiftyoneDegreesCollectionKeyType * const CollectionKeyType_Value = 
 static const fiftyoneDegreesCollectionKeyType CollectionKeyType_WKB_raw = {
     FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WKB,
     sizeof(uint16_t),
-    getFinalByteArraySize,
+    fiftyoneDegreesGetFinalByteArraySize,
 };
 static const fiftyoneDegreesCollectionKeyType * const CollectionKeyType_WKB = &CollectionKeyType_WKB_raw;
 static const fiftyoneDegreesCollectionKeyType CollectionKeyType_WKB_R_raw = {
     FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WKB_R,
     sizeof(uint16_t),
-    getFinalByteArraySize,
+    fiftyoneDegreesGetFinalByteArraySize,
 };
 static const fiftyoneDegreesCollectionKeyType * const CollectionKeyType_WKB_R = &CollectionKeyType_WKB_R_raw;
 

--- a/component.h
+++ b/component.h
@@ -99,7 +99,6 @@ typedef struct fiftyoneDegrees_component_t {
 EXTERNAL uint32_t fiftyoneDegreesComponentGetFinalSize(
 	const void *initial,
 	fiftyoneDegreesException *exception);
-
 /**
  * Returns the string name of the component using the item provided. The
  * collection item must be released when the caller is finished with the

--- a/profile.c
+++ b/profile.c
@@ -27,6 +27,7 @@
 
 MAP_TYPE(Collection)
 
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 uint32_t fiftyoneDegreesProfileGetFinalSize(
 	const void *initial,
     fiftyoneDegreesException * const exception) {
@@ -37,6 +38,7 @@ uint32_t fiftyoneDegreesProfileGetFinalSize(
 	return sizeof(Profile) +
 		(profile->valueCount * sizeof(uint32_t));
 }
+#endif
 
 static Profile* getProfileByOffset(
 	Collection *profilesCollection,

--- a/profile.h
+++ b/profile.h
@@ -159,9 +159,13 @@ typedef bool(*fiftyoneDegreesProfileIterateValueIndexesMethod)(
  * @param initial pointer to profile "head"
  * @return full (with tail) struct size
  */
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 EXTERNAL uint32_t fiftyoneDegreesProfileGetFinalSize(
 	const void *initial,
 	fiftyoneDegreesException * const exception);
+#else
+#define fiftyoneDegreesProfileGetFinalSize NULL
+#endif
 
 /**
  * Gets the profile associated with the profileId or NULL if there is no

--- a/string.c
+++ b/string.c
@@ -28,6 +28,7 @@
 
 #include "collectionKeyTypes.h"
 
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 uint32_t fiftyoneDegreesStringGetFinalSize(
 	const void *initial,
     Exception * const exception) {
@@ -36,6 +37,7 @@ uint32_t fiftyoneDegreesStringGetFinalSize(
 #	endif
 	return (uint32_t)(sizeof(int16_t) + (*(int16_t*)initial));
 }
+#endif
 
 #ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 

--- a/string.h
+++ b/string.h
@@ -96,17 +96,21 @@ typedef struct fiftyone_degrees_string_t {
 } fiftyoneDegreesString;
 #pragma pack(pop)
 
-#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
-
 /**
  * Gets size of String with trailing characters.
  * @param initial pointer to string "head"
  * @return full (with tail) struct size
  */
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 EXTERNAL uint32_t fiftyoneDegreesStringGetFinalSize(
 	const void *initial,
 	fiftyoneDegreesException *exception);
+#else
+#define fiftyoneDegreesStringGetFinalSize NULL
+#endif
 
+
+#ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 /**
  * Reads a string from the source file at the offset within the string
  * structure.


### PR DESCRIPTION
### Changes

- Fix compilation in `MemoryOnly` mode.
- Streamline `CollectionCreateFromFile` and `createFromFileToMemory` functions.
- Reset data after freeing in `fiftyoneDegreesCollectionReadFileFixed`.
- Rename `createFromFileSecond` to `createFromFileMaybeCached`.
- Fix typo in index struct name.

### Why

- https://github.com/51Degrees/ip-intelligence-cxx/issues/21

### Related

- https://github.com/51Degrees/common-cxx/pull/117