### PR TITLE
Use correct key type in `compareProfileIdIndirect`.

### DIFF
--- a/profile.c
+++ b/profile.c
@@ -91,7 +91,7 @@ static int compareProfileIdIndirect(
 	const uint32_t profileOffsetValue = *(uint32_t*)profileOffsetItem->data.ptr;
 	const CollectionKey profileKey = {
 		profileOffsetValue,
-		CollectionKeyType_ProfileOffset,
+		CollectionKeyType_Profile,
 	};
 	const Profile * const profile = (Profile*)search->profiles->get(
 		search->profiles,


### PR DESCRIPTION
### Changes

- Use correct key type in `compareProfileIdIndirect`.