### PR TITLE
FIX: memory tracking for chunks over 4GB

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -39,7 +39,7 @@ static bool initialised = false;
 
 typedef struct memory_allocation_t {
 	fiftyoneDegreesTreeNode tree; /* Tree node data structure */
-	uint32_t size; /* The amount of memory allocated at pointer */
+	size_t size; /* The amount of memory allocated at pointer */
 } allocation;
 
 typedef struct memory_allocation_tree_t {
@@ -122,7 +122,7 @@ static void trackAllocation(void* pointer, size_t size) {
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
-	record->size = (uint32_t)size;
+	record->size = size;
 
 	// Update the tracking tree with the new allocation.
 #ifndef FIFTYONE_DEGREES_NO_THREADING
@@ -148,7 +148,7 @@ static void trackAllocation(void* pointer, size_t size) {
 }
 
 static void untrackAllocation(void *pointer) {
-	uint32_t size;
+	size_t size;
 	int shard = getShardFromPointer(pointer);
 
 	// Get the size of the memory being freed and free the tracking memory.


### PR DESCRIPTION
Fixes a bug in the memory tracking code in `memory.c` that resulted in false memory leaks, f.e. here: https://github.com/51Degrees/ip-intelligence-cxx/actions/runs/18371647634/job/52336166606#step:5:1937

## Root cause

The allocation struct stored size as uint32_t (max 4GB) type.  When tracking allocation, size was truncated: `record->size = (uint32_t)size`, while `state.allocated` was incremented with the full untruncated `size_t` value.  When freeing, only the truncated `uint32_t` value was subtracted.  This caused integer overflow when allocations exceeded 4GB. 

For example:
Allocate 4.5 GB → state.allocated += 4.5GB, but stored as (uint32_t)4.5GB ≈ 0.5GB
Free → state.allocated -= 0.5GB (the truncated value)
Result: state.allocated shows 4GB leak - but there is no actual leak as the whole allocation was freed.
  
## Fix

Changed allocation size type from `uint32_t` to `size_t`.