### PR TITLE
FIX: Use _fsopen with _SH_DENYNO on Windows so in-use files can be opened (#118)

### DIFF
--- a/file.c
+++ b/file.c
@@ -27,6 +27,7 @@
 
 #ifdef _MSC_VER
 #include <windows.h>
+#include <share.h>
 #else
 #include <stdio.h>
 #include <unistd.h>
@@ -159,8 +160,14 @@ static StatusCode fileOpen(
 		}
 	}
 #else
-	/* If using Microsoft use the fopen_s method to avoid warning */
-	errno_t error = fopen_s(handle, fileName, mode);
+	/* Use _fsopen rather than fopen_s so that the file can be opened with
+	 * shared access. fopen_s opens files without sharing, which means a file
+	 * that is already open in another process (e.g. a data file still being
+	 * generated and read concurrently) cannot be opened and fails with a
+	 * permission error. _SH_DENYNO requests read/write sharing so the open
+	 * succeeds in that scenario. _fsopen sets errno on failure. */
+	*handle = _fsopen(fileName, mode, _SH_DENYNO);
+	errno_t error = (*handle == NULL) ? errno : 0;
 	if (error != 0) {
 		switch (error) {
 		case ENFILE:

--- a/tests/FileTests.cpp
+++ b/tests/FileTests.cpp
@@ -25,6 +25,10 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+#ifdef _MSC_VER
+#include <share.h>
+#endif
+
 #include "../exceptions.h"
 #include "../file.h"
 #include "../snprintf.h"
@@ -487,6 +491,40 @@ TEST_F(File, FileCopy) {
 	fclose(copy);
 	fclose(orig);
 	removeFile(copiedFileName);
+}
+
+/**
+ * Check that a file which is already open elsewhere with write access can
+ * still be opened for reading without an error. This reproduces the scenario
+ * in issue #118 where a data file is being generated/written by another
+ * process (using read/write access while sharing read access) and needs to be
+ * read concurrently. Before the fix the Windows implementation used fopen_s,
+ * which opens files without sharing and therefore failed with a permission
+ * error in this case.
+ */
+TEST_F(File, OpenWhileInUse) {
+	// Open the file with write access while permitting others to read it.
+	// This mirrors a writer using FileAccess.ReadWrite with FileShare.Read.
+	FILE *writer;
+#ifdef _MSC_VER
+	writer = _fsopen(fileName, "rb+", _SH_DENYNO);
+#else
+	writer = fopen(fileName, "rb+");
+#endif
+	ASSERT_NE((FILE *)NULL, writer) <<
+		"Could not open the file with write access to set up the test.";
+
+	// Now open the same file for reading. This must succeed even though the
+	// file is in use.
+	FILE *reader = NULL;
+	EXPECT_EQ(FIFTYONE_DEGREES_STATUS_SUCCESS,
+		fiftyoneDegreesFileOpen(fileName, &reader)) <<
+		"A file which is already in use could not be opened for reading.";
+
+	if (reader != NULL) {
+		fclose(reader);
+	}
+	fclose(writer);
 }
 
 /**


### PR DESCRIPTION
fopen_s opens files without sharing, so a data file already held open by another process (FileAccess.ReadWrite + FileShare.Read) could not be opened for reading and failed with FILE_PERMISSION_DENIED. Switch to _fsopen with _SH_DENYNO, preserving the errno-based error mapping, and add a test that opens a file while it is in use.
Addresses #118