### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Common Code Library
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=home&utm_campaign=c-open-source "Data rewards the curious") **51Degrees Common C Code**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=common-cxx&utm_content=readme.md&utm_term=51degrees-common-code-library "Data rewards the curious") **51Degrees Common C Code**
 
-[Reference Documentation](https://51degrees.com/device-detection-cxx/4.5/index.html "Reference documentation")
+[Reference Documentation](https://51degrees.com/device-detection-cxx/4.5/index.html?utm_source=github&utm_medium=readme&utm_campaign=common-cxx&utm_content=readme.md&utm_term=51degrees-common-code-library "Reference documentation")
 
 # Introduction
 

--- a/status.c
+++ b/status.c
@@ -113,7 +113,7 @@ static StatusMessage messages[] = {
 		"pool. Another way to avoid this is by using an in-memory "
 		"configuration, which avoids using file handles completely, and "
 		"removes any limit on concurrency. For info see "
-		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html"},
+		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html?utm_source=code&utm_medium=comment&utm_campaign=common-cxx&utm_content=status.c&utm_term=insufficient_handles"},
 	{ COLLECTION_INDEX_OUT_OF_RANGE,
 		"Index used to retrieve an item from a collection was out of range." },
 	{ COLLECTION_OFFSET_OUT_OF_RANGE,


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

3 links across 3 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).