### PR TITLE
FIX: Add const qualifiers to Common::Value getters

### DIFF
--- a/Value.hpp
+++ b/Value.hpp
@@ -97,7 +97,7 @@ namespace FiftyoneDegrees {
 			 * ResultsBase instance.
 			 * @return true if there is a valid value
 			 */
-			bool hasValue() {
+			bool hasValue() const {
 				return hasValueInternal;
 			}
 
@@ -107,7 +107,7 @@ namespace FiftyoneDegrees {
              * message, call getNoValueMessage().
              * @return enum indicating the reason for no valid values
              */
-			fiftyoneDegreesResultsNoValueReason getNoValueReason() {
+			fiftyoneDegreesResultsNoValueReason getNoValueReason() const {
 				return noValueReason;
 			}
 
@@ -116,7 +116,7 @@ namespace FiftyoneDegrees {
 			 * hasValue() returned true will result in undefined behavior.
 			 * @return message explaining the reason for the missing value
 			 */
-			const char* getNoValueMessage() {
+			const char* getNoValueMessage() const {
 				return noValueMessage;
 			}
 
@@ -126,7 +126,7 @@ namespace FiftyoneDegrees {
 			 * exception, the hasValue() method should be checked first.
 			 * @return value
 			 */
-			T getValue() {
+			T getValue() const {
 				if (hasValueInternal) {
 					return value;
 				}
@@ -188,7 +188,7 @@ namespace FiftyoneDegrees {
 			 * exception, the hasValue() method should be checked first.
 			 * @return value
 			 */
-			T operator*() {
+			T operator*() const {
 				return getValue();
 			}
 

--- a/tests/ValueTests.cpp
+++ b/tests/ValueTests.cpp
@@ -203,3 +203,50 @@ TEST_F(ValueTests, PointerType) {
 
 	delete expected;
 }
+
+/**
+ * Check that every read-only method can be called on a const Value. This guards
+ * against a regression of the reported issue where the getters were missing the
+ * const qualifier, so code such as
+ *     Value<string> const v = results->getValueAsString(index);
+ *     if (v.hasValue()) { ... }
+ * failed to compile. This test will not compile if any read method loses its
+ * const qualifier.
+ */
+TEST_F(ValueTests, ConstAccessWithValue) {
+	int expected = 51;
+	Value<int> value;
+	value.setValue(expected);
+
+	const Value<int> &constValue = value;
+
+	EXPECT_TRUE(constValue.hasValue()) <<
+		L"hasValue() should be callable on a const Value and return true.";
+	EXPECT_EQ(expected, constValue.getValue()) <<
+		L"getValue() should be callable on a const Value and return the value.";
+	EXPECT_EQ(expected, *constValue) <<
+		L"operator*() should be callable on a const Value and return the value.";
+}
+
+/**
+ * Check that the no-value read methods are also callable on a const Value, so
+ * the const path can inspect why a value is missing.
+ */
+TEST_F(ValueTests, ConstAccessNoValue) {
+	const char *expected = "some error message";
+	Value<int> value;
+	value.setNoValueReason(
+		FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NO_RESULTS,
+		expected);
+
+	const Value<int> &constValue = value;
+
+	EXPECT_FALSE(constValue.hasValue()) <<
+		L"hasValue() should be callable on a const Value and return false.";
+	EXPECT_EQ(
+		FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NO_RESULTS,
+		constValue.getNoValueReason()) <<
+		L"getNoValueReason() should be callable on a const Value.";
+	EXPECT_STREQ(expected, constValue.getNoValueMessage()) <<
+		L"getNoValueMessage() should be callable on a const Value.";
+}


### PR DESCRIPTION
The read-only methods of Common::Value<T> (hasValue, getValue, getNoValueMessage, getNoValueReason and operator*) were not const-qualified, so a const Value instance could not be inspected.

Add ConstAccessWithValue and ConstAccessNoValue regression tests that exercise every read method through a const reference. These fail to compile if a getter loses its const qualifier.

Closes #108 