### PR TITLE
BUG/FEAT: Strip serializer double quotes in YAML evidence reader

### DIFF
--- a/tests/YamlFileTests.cpp
+++ b/tests/YamlFileTests.cpp
@@ -326,3 +326,137 @@ TEST(YamlFileIteratorTests, NoLimitLastDocEmptyNoEOFNewLine) {
 	};
 	testYamlFileIterator({ false, -1, true, true }, expected);
 }
+
+/*
+ * Write the exact bytes given to a temp file (binary mode, so newlines are not
+ * translated and the caller controls CRLF precisely).
+ */
+static void writeRawFile(const string& path, const string& content) {
+	FILE* fp = fopen(path.c_str(), "wb");
+	if (fp != NULL) {
+		if (!content.empty()) {
+			fwrite(content.data(), 1, content.size(), fp);
+		}
+		fclose(fp);
+	}
+}
+
+/*
+ * Iterate over the given raw file content using a caller supplied read buffer
+ * size. A small buffer forces records to span file blocks, exercising the
+ * block boundary handling.
+ */
+static TestState iterateRaw(const string& content, size_t bufferSize) {
+	string filePath = getFileWithPath("quotefile");
+	writeRawFile(filePath, content);
+
+	vector<char> buffer(bufferSize, 0);
+	char key[8][256];
+	char value[8][256];
+	KeyValuePair pairs[8];
+	for (int i = 0; i < 8; i++) {
+		pairs[i] = { key[i], 256, value[i], 256 };
+	}
+	TestState state;
+	fiftyoneDegreesYamlFileIterateWithLimit(
+		filePath.c_str(),
+		buffer.data(),
+		bufferSize,
+		pairs,
+		8,
+		-1,
+		&state,
+		testCallBack);
+	deleteTestFile(filePath);
+	return state;
+}
+
+/*
+ * Read back the single value from a single "header.X: ..." record.
+ */
+static string valueOf(const string& record) {
+	TestState s = iterateRaw(record, 500);
+	if (s.size() == 1 && s[0].size() == 1) {
+		return s[0][0].value;
+	}
+	return string("<unexpected docs=") + std::to_string(s.size()) + ">";
+}
+
+TEST(YamlFileQuoteTests, DoubleQuoteWrappedSingleQuoteStripped) {
+	ASSERT_EQ(string("'hello world"), valueOf("header.ua: \"'hello world\""));
+}
+
+TEST(YamlFileQuoteTests, DoubleQuoteWrappedLeadingWhitespace) {
+	ASSERT_EQ(string(" 'hello world"), valueOf("header.ua: \" 'hello world\""));
+}
+
+// Check client Hint values are NOT stripped of doublr quotes.
+TEST(YamlFileQuoteTests, ClientHintDoubleQuotesPreserved) {
+	string ch = "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"126\"";
+	ASSERT_EQ(ch, valueOf("header.sec-ch-ua: " + ch));
+}
+
+TEST(YamlFileQuoteTests, ClientHintSingleQuoteWrappedUnwrapped) {
+	ASSERT_EQ(string("\"Chromium\";v=\"8\""),
+		valueOf("header.sec-ch-ua: '\"Chromium\";v=\"8\"'"));
+}
+
+TEST(YamlFileQuoteTests, SingleQuoteMidStringUntouched) {
+	ASSERT_EQ(string("hello' world"), valueOf("header.ua: hello' world"));
+}
+TEST(YamlFileQuoteTests, SingleQuoteTrailingUntouched) {
+	ASSERT_EQ(string("hello world'"), valueOf("header.ua: hello world'"));
+}
+
+TEST(YamlFileQuoteTests, SingleQuoteWrappingStillStripped) {
+	ASSERT_EQ(string("hello world"), valueOf("header.ua: 'hello world'"));
+}
+
+// Check that a double-quote wrapped value as the last pair of a document,
+// read with a tiny buffer (so the value spans several file blocks) is still 
+// unwrapped.
+TEST(YamlFileQuoteTests, DoubleQuoteWrappedAcrossBlocks) {
+	TestState s = iterateRaw("header.ua: \"'spanning value\"", 4);
+	ASSERT_EQ((size_t)1, s.size());
+	ASSERT_EQ((size_t)1, s[0].size());
+	ASSERT_EQ(string("'spanning value"), s[0][0].value);
+}
+
+// An empty file is not a document and must yield no pairs.
+TEST(YamlFileDocumentTests, EmptyFileYieldsNoDocuments) {
+	ASSERT_EQ((size_t)0, iterateRaw("", 500).size());
+}
+
+// A file of only blank lines must not emit a phantom empty pair.
+TEST(YamlFileDocumentTests, BlankLinesYieldNoDocuments) {
+	ASSERT_EQ((size_t)0, iterateRaw("\n\n\n", 500).size());
+	ASSERT_EQ((size_t)0, iterateRaw("\r\n\r\n", 500).size());
+}
+
+// A single pair with no trailing newline is returned in full.
+TEST(YamlFileDocumentTests, SinglePairNoTrailingNewLine) {
+	TestState s = iterateRaw("header.a: 1", 500);
+	ASSERT_EQ((size_t)1, s.size());
+	ASSERT_EQ((size_t)1, s[0].size());
+	ASSERT_EQ(string("1"), s[0][0].value);
+}
+
+// The last document is returned even with no terminating separator or newline.
+TEST(YamlFileDocumentTests, LastDocumentReturnedAtEof) {
+	TestState s = iterateRaw("header.a: 1\nheader.b: 2\n---\nheader.c: 3", 500);
+	ASSERT_EQ((size_t)2, s.size());
+	ASSERT_EQ((size_t)2, s[0].size());
+	ASSERT_EQ((size_t)1, s[1].size());
+	ASSERT_EQ(string("3"), s[1][0].value);
+}
+
+// CRLF line endings, read with a tiny buffer, produce the same documents.
+TEST(YamlFileDocumentTests, CrlfWithSmallBuffer) {
+	string content = "header.a: 1\r\nheader.b: 2\r\n---\r\nheader.c: 3";
+	for (size_t bs = 2; bs <= (size_t)8; bs++) {
+		TestState s = iterateRaw(content, bs);
+		ASSERT_EQ((size_t)2, s.size()) << "buffer size " << bs;
+		ASSERT_EQ((size_t)2, s[0].size()) << "buffer size " << bs;
+		ASSERT_EQ((size_t)1, s[1].size()) << "buffer size " << bs;
+	}
+}

--- a/yamlfile.c
+++ b/yamlfile.c
@@ -139,14 +139,37 @@ static bool isValue(FileState* state) {
 
 // Adds the character to the key value pair if the conditions are met.
 static void addCharacter(
-	PairState* pairState, 
-	FileState* fileState, 
+	PairState* pairState,
+	FileState* fileState,
 	char* current) {
 	if (pairState->current < pairState->end &&
 		pairState->index < pairState->size &&
 		isValue(fileState)) {
 		*pairState->current = *current;
 		pairState->current++;
+	}
+}
+
+// Removes wrapping double quotes that YAML serializers add around a value
+// where the first non-whitespace character is a single quote 
+// e.g. "'hello world" -> 'hello world.
+// Client Hint headers such as "Chromium";v="8" whose double quotes
+// are part of the value are left untouched.
+static void stripDoubleQuoteWrap(PairState* state) {
+	char* start = (char*)(state->pairs + state->index)->value;
+	// The last character written to the value. current points one beyond it.
+	char* last = state->current - 1;
+	if (last > start && *start == '"' && *last == '"') {
+		char* inner = start + 1;
+		while (inner < last && (*inner == ' ' || *inner == '\t')) {
+			inner++;
+		}
+		if (inner < last && *inner == '\'') {
+			// Shift the body left over the opening quote and drop the trailing
+			// quote by moving the write pointer back over both quotes.
+			memmove(start, start + 1, (size_t)(last - (start + 1)));
+			state->current -= 2;
+		}
 	}
 }
 
@@ -199,13 +222,22 @@ StatusCode fiftyoneDegreesYamlFileIterateWithLimit(
 
 		// If EOF or the first new line then move to the next pair.
 		if (!current || *current == '\n' || *current == '\r') {
-			if (fileState.newLineCount == 0) {
+			// Only finalise a pair if one is actually in progress. Position is
+			// zero on a blank line or an empty file so finalising there would 
+			// emit a phantom empty.
+			if (fileState.newLineCount == 0 && fileState.position > 0) {
 
-				// If there was a quote earlier in the string and the last one
-				// is also a quote then remove the last quote.
-				if (fileState.quote > 0 && 
+				// If the value opened with a single quote and the last
+				// character is also a single quote then remove the trailing
+				// quote (the opening one was skipped while reading).
+				if (fileState.quote > 0 &&
 					*(pairState.current - 1) == '\'') {
 					pairState.current--;
+				}
+				// If there is a value, remove any wrapping double
+				// quotes the serializer added around a leading single quote.
+				else if (fileState.colon > 0) {
+					stripDoubleQuoteWrap(&pairState);
 				}
 				nextPair(&pairState);
 			}

--- a/yamlfile.h
+++ b/yamlfile.h
@@ -50,6 +50,21 @@
  * - pair ::= key separator white-space value
  * - documents ::= document* docs-end
  * - document = doc-start linefeed pair*
+ *
+ * Quoted values:
+ * Evidence files can contain values wrapped in quotes when they contain
+ * special characters. The reader removes the wrapping quotes so the
+ * original value is recovered:
+ * - A value wrapped in single quotes, e.g. 'value', has them removed.
+ * - A value wrapped in double quotes is only unwrapped when the first
+ *   non-whitespace character inside the quotes is a single quote, e.g.
+ *   "'value" is the form a serializer uses for a value that begins with a
+ *   single quote. This is the only case in which such a serializer emits
+ *   double quotes, so double quotes are otherwise left in place. In particular
+ *   Client Hint headers such as "Chromium";v="8" keep their double quotes,
+ *   which are part of the value.
+ * - Single quotes that are not the first non-whitespace character of the value
+ *   are part of the value and are left untouched.
  */
 
 /**


### PR DESCRIPTION
The evidence reader removed single-quote wrapping from values but not the double-quote wrapping that a YAML serializer such as YamlDotNet adds when a value's first non-whitespace character is a single quote, for example "'hello world".

Also stop an empty or blank document from finalising a phantom empty pair.

Add tests covering new logic..

Closes #39 