### PR TITLE
FEAT: Add profile offset keyed property value index

### DIFF
--- a/fiftyone.h
+++ b/fiftyone.h
@@ -214,6 +214,7 @@ MAP_TYPE(WeightedItemList)
 #define PropertyGet fiftyoneDegreesPropertyGet /**< Synonym for #fiftyoneDegreesPropertyGet function. */
 #define ProfileIterateValuesForProperty fiftyoneDegreesProfileIterateValuesForProperty /**< Synonym for #fiftyoneDegreesProfileIterateValuesForProperty function. */
 #define ProfileIterateValuesForPropertyWithIndex fiftyoneDegreesProfileIterateValuesForPropertyWithIndex /**< Synonym for #fiftyoneDegreesProfileIterateValuesForPropertyWithIndex function. */
+#define ProfileIterateValuesForPropertyWithIndexAndOffset fiftyoneDegreesProfileIterateValuesForPropertyWithIndexAndOffset /**< Synonym for #fiftyoneDegreesProfileIterateValuesForPropertyWithIndexAndOffset function. */
 #define ProfileIterateValueIndexes fiftyoneDegreesProfileIterateValueIndexes /**< Synonym for #fiftyoneDegreesProfileIterateValueIndexes function. */
 #define ProfileIterateProfilesForPropertyAndValue fiftyoneDegreesProfileIterateProfilesForPropertyAndValue /**< Synonym for #fiftyoneDegreesProfileIterateProfilesForPropertyAndValue function. */
 #define ProfileIterateProfilesForPropertyWithTypeAndValue fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue /**< Synonym for #fiftyoneDegreesProfileIterateProfilesForPropertyWithTypeAndValue function. */
@@ -378,8 +379,10 @@ MAP_TYPE(WeightedItemList)
 #define YamlFileIterate fiftyoneDegreesYamlFileIterate /**< Synonym for fiftyoneDegreesYamlFileIterate */
 #define YamlFileIterateWithLimit fiftyoneDegreesYamlFileIterateWithLimit /**< Synonym for fiftyoneDegreesYamlFileIterateWithLimit */
 #define IndicesPropertyProfileCreate fiftyoneDegreesIndicesPropertyProfileCreate /**< Synonym for fiftyoneDegreesIndicesPropertyProfileCreate */
+#define IndicesPropertyProfileCreateFromOffsets fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets /**< Synonym for fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets */
 #define IndicesPropertyProfileFree fiftyoneDegreesIndicesPropertyProfileFree /**< Synonym for fiftyoneDegreesIndicesPropertyProfileFree */
 #define IndicesPropertyProfileLookup fiftyoneDegreesIndicesPropertyProfileLookup /**< Synonym for fiftyoneDegreesIndicesPropertyProfileLookup */
+#define IndicesPropertyProfileLookupByOffset fiftyoneDegreesIndicesPropertyProfileLookupByOffset /**< Synonym for fiftyoneDegreesIndicesPropertyProfileLookupByOffset */
 #define JsonDocumentStart fiftyoneDegreesJsonDocumentStart /**< Synonym for fiftyoneDegreesJsonDocumentStart */
 #define JsonDocumentEnd fiftyoneDegreesJsonDocumentEnd /**< Synonym for fiftyoneDegreesJsonDocumentEnd */
 #define JsonPropertyStart fiftyoneDegreesJsonPropertyStart /**< Synonym for fiftyoneDegreesJsonPropertyStart */

--- a/indices.c
+++ b/indices.c
@@ -22,6 +22,8 @@
 
 #include "indices.h"
 
+#include <string.h>
+
 #include "collectionKeyTypes.h"
 #include "fiftyone.h"
 
@@ -31,41 +33,23 @@ typedef struct map_t {
 	int16_t propertyIndex; // index in the properties collection
 } map;
 
-// Gets the index of the profile id in the property profile index.
-static uint32_t getProfileIdIndex(
-	IndicesPropertyProfile* index, 
-	uint32_t profileId) {
-	return profileId - index->minProfileId;
-}
-
-// Loops through the values associated with the profile setting the index at 
+// Loops through the values associated with the profile setting the index at
 // the position for the property and profile to the first value index from the
-// profile.
+// profile. The base is the index in valueIndexes of the first cell of the row
+// used for the profile.
 static void addProfileValuesMethod(
 	IndicesPropertyProfile* index, // index in use or null if not available
 	map* propertyIndexes, // property indexes in ascending order
 	fiftyoneDegreesCollection* values, // collection of values
-	Profile* profile, 
+	Profile* profile,
+	uint32_t base,
 	Exception* exception) {
-#ifdef FIFTYONE_DEGREES_REDUCED_FILE
-	// A reduced size data file does not contain profile ids, so this method
-	// cannot be implemented.
-#ifdef _MSC_VER
-	UNREFERENCED_PARAMETER(index);
-	UNREFERENCED_PARAMETER(propertyIndexes);
-	UNREFERENCED_PARAMETER(values);
-	UNREFERENCED_PARAMETER(profile);
-#endif
-	EXCEPTION_SET(NOT_IMPLEMENTED);
-#else
 	uint32_t valueIndex;
 	Item valueItem; // The current value memory
 	Value* value; // The current value pointer
 	DataReset(&valueItem.data);
-	
+
 	uint32_t* first = (uint32_t*)(profile + 1); // First value for the profile
-	uint32_t base = getProfileIdIndex(index, profile->profileId) * 
-		index->availablePropertyCount;
 
 	CollectionKey valueKey = {
 		0,
@@ -83,15 +67,15 @@ static void addProfileValuesMethod(
 		value = values->get(values, &valueKey, &valueItem, exception);
 		if (value != NULL && EXCEPTION_OKAY) {
 
-			// If the value doesn't relate to the next property index then 
+			// If the value doesn't relate to the next property index then
 			// move to the next property index.
-			while (p < index->availablePropertyCount && // first check validity 
+			while (p < index->availablePropertyCount && // first check validity
 				// of the subscript and then use it
                 propertyIndexes[p].propertyIndex < value->propertyIndex) {
 				p++;
 			}
 
-			// If the value relates to the next property index being sought 
+			// If the value relates to the next property index being sought
 			// then record the first value in the profile associated with the
 			// property.
 			if (p < index->availablePropertyCount &&
@@ -104,7 +88,15 @@ static void addProfileValuesMethod(
 			COLLECTION_RELEASE(values, &valueItem);
 		}
 	}
-#endif
+}
+
+#ifndef FIFTYONE_DEGREES_REDUCED_FILE
+
+// Gets the index of the profile id in the property profile index.
+static uint32_t getProfileIdIndex(
+	IndicesPropertyProfile* index,
+	uint32_t profileId) {
+	return profileId - index->minProfileId;
 }
 
 static void iterateProfiles(
@@ -128,7 +120,7 @@ static void iterateProfiles(
 		0,
 		CollectionKeyType_Profile,
 	};
-	for (uint32_t i = 0; 
+	for (uint32_t i = 0;
 		i < index->profileCount && EXCEPTION_OKAY;
 		i++) {
 		profileOffsetKey.indexOrOffset.offset = i;
@@ -150,6 +142,8 @@ static void iterateProfiles(
 					propertyIndexes,
 					values,
 					profile,
+					getProfileIdIndex(index, profile->profileId) *
+						index->availablePropertyCount,
 					exception);
 				COLLECTION_RELEASE(profiles, &profileItem);
 			}
@@ -158,22 +152,12 @@ static void iterateProfiles(
 	}
 }
 
-// As the profileOffsets collection is ordered in ascending profile id the 
+// As the profileOffsets collection is ordered in ascending profile id the
 // first and last entries are the min and max available profile ids.
 static uint32_t getProfileId(
 	fiftyoneDegreesCollection* profileOffsets,
 	uint32_t index,
 	Exception* exception) {
-#ifdef FIFTYONE_DEGREES_REDUCED_FILE
-	// A reduced size data file does not contain profile ids, so this method
-	// cannot be implemented.
-#ifdef _MSC_VER
-	UNREFERENCED_PARAMETER(profileOffsets);
-	UNREFERENCED_PARAMETER(index);
-#endif
-	EXCEPTION_SET(NOT_IMPLEMENTED);
-	return 0;
-#else
 	uint32_t profileId = 0;
 	ProfileOffset* profileOffset; // The profile offset pointer
 	Item profileOffsetItem; // The profile offset memory
@@ -192,8 +176,9 @@ static uint32_t getProfileId(
 		COLLECTION_RELEASE(profileOffsets, &profileOffsetItem);
 	}
 	return profileId;
-#endif
 }
+
+#endif
 
 static int comparePropertyIndexes(const void* a, const void* b) {
 	return ((map*)a)->propertyIndex - ((map*)b)->propertyIndex;
@@ -223,6 +208,19 @@ fiftyoneDegreesIndicesPropertyProfileCreate(
 	fiftyoneDegreesPropertiesAvailable* available,
 	fiftyoneDegreesCollection* values,
 	fiftyoneDegreesException* exception) {
+#ifdef FIFTYONE_DEGREES_REDUCED_FILE
+	// A reduced size data file does not contain profile ids, so a profile id
+	// keyed index cannot be created. Use
+	// fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets instead.
+#ifdef _MSC_VER
+	UNREFERENCED_PARAMETER(profiles);
+	UNREFERENCED_PARAMETER(profileOffsets);
+	UNREFERENCED_PARAMETER(available);
+	UNREFERENCED_PARAMETER(values);
+#endif
+	EXCEPTION_SET(NOT_IMPLEMENTED);
+	return NULL;
+#else
 
 	// Create the ordered list of property indexes.
 	map* propertyIndexes = createPropertyIndexes(available, exception);
@@ -238,6 +236,7 @@ fiftyoneDegreesIndicesPropertyProfileCreate(
 		return NULL;
 	}
 	index->filled = 0;
+	index->profileOffsets = NULL; // keyed by profile id
 	index->profileCount = CollectionGetCount(profileOffsets);
 	index->minProfileId = getProfileId(profileOffsets, 0, exception);
 	if (!EXCEPTION_OKAY) {
@@ -287,10 +286,182 @@ fiftyoneDegreesIndicesPropertyProfileCreate(
 		Free(index);
 		return NULL;
 	}
+#endif
+}
+
+// Ascending order comparison for two profile offsets.
+static int compareProfileOffsets(const void* a, const void* b) {
+	const uint32_t offsetA = *(const uint32_t*)a;
+	const uint32_t offsetB = *(const uint32_t*)b;
+	return offsetA < offsetB ? -1 : (offsetA > offsetB ? 1 : 0);
+}
+
+// Gets the pure profile offset for the entry at entryIndex in the
+// profileOffsets collection using the extractor provided. Returns true if the
+// entry was read successfully.
+static bool getPureProfileOffset(
+	fiftyoneDegreesCollection* profileOffsets,
+	fiftyoneDegreesProfileOffsetValueExtractor offsetValueExtractor,
+	uint32_t entryIndex,
+	uint32_t* pureOffset,
+	Exception* exception) {
+	Item entryItem; // The current profile offset entry memory
+	DataReset(&entryItem.data);
+	const CollectionKey entryKey = {
+		entryIndex,
+		CollectionKeyType_ProfileOffset,
+	};
+	const void* rawEntry = profileOffsets->get(
+		profileOffsets,
+		&entryKey,
+		&entryItem,
+		exception);
+	if (rawEntry == NULL || EXCEPTION_FAILED) {
+		return false;
+	}
+	*pureOffset = offsetValueExtractor(rawEntry);
+	COLLECTION_RELEASE(profileOffsets, &entryItem);
+	return true;
+}
+
+fiftyoneDegreesIndicesPropertyProfile*
+fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets(
+	fiftyoneDegreesCollection* profiles,
+	fiftyoneDegreesCollection* profileOffsets,
+	fiftyoneDegreesProfileOffsetValueExtractor offsetValueExtractor,
+	fiftyoneDegreesPropertiesAvailable* available,
+	fiftyoneDegreesCollection* values,
+	fiftyoneDegreesException* exception) {
+	uint32_t i;
+	Profile* profile; // The current profile pointer
+	Item profileItem; // The current profile memory
+
+	// Check the number of cells needed can be counted and addressed.
+	const uint32_t entryCount = CollectionGetCount(profileOffsets);
+	if (entryCount == 0 ||
+		available->count == 0 ||
+		(uint64_t)entryCount * available->count > (uint64_t)UINT32_MAX) {
+		return NULL;
+	}
+
+	// Create the ordered list of property indexes.
+	map* propertyIndexes = createPropertyIndexes(available, exception);
+	if (propertyIndexes == NULL) {
+		return NULL;
+	}
+
+	// Allocate memory for the index and set the fields.
+	IndicesPropertyProfile* index = (IndicesPropertyProfile*)Malloc(
+		sizeof(IndicesPropertyProfile));
+	if (index == NULL) {
+		EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY);
+		Free(propertyIndexes);
+		return NULL;
+	}
+	index->filled = 0;
+	index->minProfileId = 0; // unused when keyed by profile offset
+	index->maxProfileId = 0; // unused when keyed by profile offset
+	index->availablePropertyCount = available->count;
+
+	// Read all the profile offsets into an array sorted in ascending order
+	// with any duplicate entries removed.
+	index->profileOffsets = (uint32_t*)Malloc(
+		sizeof(uint32_t) * entryCount);
+	if (index->profileOffsets == NULL) {
+		EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY);
+		Free(index);
+		Free(propertyIndexes);
+		return NULL;
+	}
+	uint32_t count = 0;
+	for (i = 0; i < entryCount && EXCEPTION_OKAY; i++) {
+		uint32_t pureOffset;
+		if (getPureProfileOffset(
+			profileOffsets,
+			offsetValueExtractor,
+			i,
+			&pureOffset,
+			exception)) {
+			index->profileOffsets[count++] = pureOffset;
+		}
+	}
+	if (EXCEPTION_FAILED || count == 0) {
+		Free(index->profileOffsets);
+		Free(index);
+		Free(propertyIndexes);
+		return NULL;
+	}
+	qsort(
+		index->profileOffsets,
+		count,
+		sizeof(uint32_t),
+		compareProfileOffsets);
+	uint32_t distinct = 1;
+	for (i = 1; i < count; i++) {
+		if (index->profileOffsets[i] != index->profileOffsets[distinct - 1]) {
+			index->profileOffsets[distinct++] = index->profileOffsets[i];
+		}
+	}
+	index->profileCount = distinct;
+	index->size = distinct * available->count;
+
+	// Allocate memory for the value indexes and set every cell to the no
+	// value marker so that profiles without values for a property can be
+	// identified.
+	index->valueIndexes = (uint32_t*)Malloc(sizeof(uint32_t) * index->size);
+	if (index->valueIndexes == NULL) {
+		EXCEPTION_SET(FIFTYONE_DEGREES_STATUS_INSUFFICIENT_MEMORY);
+		Free(index->profileOffsets);
+		Free(index);
+		Free(propertyIndexes);
+		return NULL;
+	}
+	memset(index->valueIndexes, 0xFF, sizeof(uint32_t) * index->size);
+
+	// For each of the distinct profile offsets add the property value indexes
+	// to the row for the profile.
+	DataReset(&profileItem.data);
+	CollectionKey profileKey = {
+		0,
+		CollectionKeyType_Profile,
+	};
+	for (i = 0; i < distinct && EXCEPTION_OKAY; i++) {
+		profileKey.indexOrOffset.offset = index->profileOffsets[i];
+		profile = (Profile*)profiles->get(
+			profiles,
+			&profileKey,
+			&profileItem,
+			exception);
+		if (profile != NULL && EXCEPTION_OKAY) {
+			addProfileValuesMethod(
+				index,
+				propertyIndexes,
+				values,
+				profile,
+				i * index->availablePropertyCount,
+				exception);
+			COLLECTION_RELEASE(profiles, &profileItem);
+		}
+	}
+	Free(propertyIndexes);
+
+	// Return the index or free the memory if there was an exception.
+	if (EXCEPTION_OKAY) {
+		return index;
+	}
+	else {
+		Free(index->valueIndexes);
+		Free(index->profileOffsets);
+		Free(index);
+		return NULL;
+	}
 }
 
 void fiftyoneDegreesIndicesPropertyProfileFree(
 	fiftyoneDegreesIndicesPropertyProfile* index) {
+	if (index->profileOffsets != NULL) {
+		Free(index->profileOffsets);
+	}
 	Free(index->valueIndexes);
 	Free(index);
 }
@@ -299,9 +470,54 @@ uint32_t fiftyoneDegreesIndicesPropertyProfileLookup(
 	fiftyoneDegreesIndicesPropertyProfile* index,
 	uint32_t profileId,
 	uint32_t availablePropertyIndex) {
-	uint32_t valueIndex = 
-		(getProfileIdIndex(index, profileId) * index->availablePropertyCount) + 
+#ifdef FIFTYONE_DEGREES_REDUCED_FILE
+	// A reduced size data file does not contain profile ids, so a profile id
+	// keyed index is never created.
+#ifdef _MSC_VER
+	UNREFERENCED_PARAMETER(index);
+	UNREFERENCED_PARAMETER(profileId);
+	UNREFERENCED_PARAMETER(availablePropertyIndex);
+#endif
+	assert(false);
+	return 0;
+#else
+	uint32_t valueIndex =
+		(getProfileIdIndex(index, profileId) * index->availablePropertyCount) +
 		availablePropertyIndex;
 	assert(valueIndex < index->size);
 	return index->valueIndexes[valueIndex];
+#endif
+}
+
+bool fiftyoneDegreesIndicesPropertyProfileLookupByOffset(
+	const fiftyoneDegreesIndicesPropertyProfile* index,
+	uint32_t profileOffset,
+	uint32_t availablePropertyIndex,
+	uint32_t* firstValueIndex) {
+	if (index == NULL ||
+		index->profileOffsets == NULL ||
+		availablePropertyIndex >= index->availablePropertyCount) {
+		return false;
+	}
+
+	// Binary search for the row relating to the profile offset.
+	uint32_t lower = 0;
+	uint32_t upper = index->profileCount;
+	while (lower < upper) {
+		const uint32_t middle = lower + (upper - lower) / 2;
+		if (index->profileOffsets[middle] < profileOffset) {
+			lower = middle + 1;
+		}
+		else {
+			upper = middle;
+		}
+	}
+	if (lower >= index->profileCount ||
+		index->profileOffsets[lower] != profileOffset) {
+		return false;
+	}
+	*firstValueIndex = index->valueIndexes[
+		((uint64_t)lower * index->availablePropertyCount) +
+			availablePropertyIndex];
+	return true;
 }

--- a/indices.h
+++ b/indices.h
@@ -27,64 +27,76 @@
   * @ingroup FiftyOneDegreesCommon
   * @defgroup FiftyOneDegreesIndices Indices
   *
-  * A look up structure for profile and property index to the first value 
+  * A look up structure for profile and property index to the first value
   * associated with the property and profile.
   *
   * ## Introduction
-  * 
+  *
   * Data sets relate profiles to the values associated with them. Values are
-  * associated with properties. The values associated with a profile are 
+  * associated with properties. The values associated with a profile are
   * ordered in ascending order of property. Therefore when a request is made to
-  * obtain the value for a property and profile the values needed to be 
-  * searched using a binary search to find a value related to the property. 
-  * Then the list of prior values is checked until the first value for the 
+  * obtain the value for a property and profile the values needed to be
+  * searched using a binary search to find a value related to the property.
+  * Then the list of prior values is checked until the first value for the
   * property is found.
-  * 
+  *
   * The indices methods provide common functionality to create a structure
-  * that directly relates profile ids and required property indexes to the 
+  * that directly relates profile ids and required property indexes to the
   * first value index thus increasing the efficiency of retrieving values.
-  * 
+  *
   * It is expected these methods will be used during data set initialization.
-  * 
+  *
   * ## Structure
-  * 
+  *
   * A sparse array of profile ids and required property indexes is used. Whilst
-  * this consumes more linear memory than a binary tree or other structure it 
-  * is extremely fast to retrieve values from. As the difference between the 
-  * lowest and highest profile id is relatively small the memory associated 
-  * with absent profile ids is considered justifiable considering the 
+  * this consumes more linear memory than a binary tree or other structure it
+  * is extremely fast to retrieve values from. As the difference between the
+  * lowest and highest profile id is relatively small the memory associated
+  * with absent profile ids is considered justifiable considering the
   * performance benefit. A further optimization is to use the required property
-  * index rather than the index of all possible properties contained in the 
-  * data set. In most use cases the caller only requires a sub set of 
+  * index rather than the index of all possible properties contained in the
+  * data set. In most use cases the caller only requires a sub set of
   * properties to be available for retrieval.
-  * 
+  *
+  * ## Profile offset keyed indexes
+  *
+  * Some data files (for example IP Intelligence, and any reduced size data
+  * file) do not contain profile ids. For these data files an alternative,
+  * profile offset keyed, form of the index is created with
+  * fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets. Instead of a sparse
+  * array keyed by profile id, a dense array of one row per distinct profile
+  * offset is used together with a sorted array of the offsets. Lookup is
+  * performed with fiftyoneDegreesIndicesPropertyProfileLookupByOffset which
+  * binary searches the sorted offsets to find the row.
+  *
   * ## Create
-  * 
+  *
   * fiftyoneDegreesIndicesPropertyProfileCreate should be called once the data
   * set is initialized with the required data structures. Memory is allocated
   * by the method and a pointer to the index data structure is returned. The
   * caller is not expected to use the returned data structure directly.
-  * 
-  * Some working memory is allocated during the indexing process. Therefore 
+  *
+  * Some working memory is allocated during the indexing process. Therefore
   * this method must be called before a freeze on allocating new memory is
   * required.
-  * 
+  *
   * ## Free
-  * 
+  *
   * fiftyoneDegreesIndicesPropertyProfileFree is used to free the memory used
   * by the index returned from Create. Must be called during the freeing of the
   * related data set.
-  * 
+  *
   * ## Lookup
-  * 
+  *
   * fiftyoneDegreesIndicesPropertyProfileLookup is used to return the index in
   * the values associated with the profile for the profile id and the required
   * property index.
-  * 
+  *
   * @{
   */
 
 #include <stdint.h>
+#include <stdbool.h>
 #ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 5105) 
@@ -101,10 +113,30 @@
 #include "common.h"
 
 /**
- * Maps the profile index and the property index to the first value index of 
- * the profile for the property. Is an array of uint32_t with entries equal to 
+ * Function that extracts a "pure" profile offset from a value inside the
+ * `profileOffsets` collection. Data files with full
+ * #fiftyoneDegreesProfileOffset entries use
+ * #fiftyoneDegreesProfileOffsetToPureOffset, data files where the entries are
+ * plain 32 bit offsets use #fiftyoneDegreesProfileOffsetAsPureOffset. See
+ * profile.h.
+ * @param rawProfileOffset a "raw" value retrieved from `profileOffsets`
+ * @return Offset to the profile in the profiles structure
+ */
+typedef uint32_t (*fiftyoneDegreesProfileOffsetValueExtractor)(
+	const void *rawProfileOffset);
+
+/**
+ * Maps the profile index and the property index to the first value index of
+ * the profile for the property. Is an array of uint32_t with entries equal to
  * the number of properties multiplied by the difference between the lowest and
  * highest profile id.
+ *
+ * When created with fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets
+ * the index is keyed by profile offset rather than profile id: profileOffsets
+ * is a sorted array with profileCount distinct entries, valueIndexes holds one
+ * row of availablePropertyCount entries per offset, and minProfileId and
+ * maxProfileId are unused. Cells with no value for the property are set to
+ * UINT32_MAX.
  */
 typedef struct fiftyone_degrees_index_property_profile{
 	uint32_t* valueIndexes; // array of value indexes
@@ -114,6 +146,8 @@ typedef struct fiftyone_degrees_index_property_profile{
 	uint32_t profileCount; // total number of profiles
 	uint32_t size; // number elements in the valueIndexes array
 	uint32_t filled; // number of elements with values
+	uint32_t* profileOffsets; // sorted distinct profile offsets when keyed by
+							  // offset, or NULL when keyed by profile id
 } fiftyoneDegreesIndicesPropertyProfile;
 
 /**
@@ -137,7 +171,36 @@ fiftyoneDegreesIndicesPropertyProfileCreate(
 	fiftyoneDegreesException* exception);
 
 /**
- * Frees an index previously created by 
+ * Create an index keyed by profile offset rather than profile id for the
+ * profiles, available properties, and values provided. Suitable for data
+ * files where the profiles do not contain profile ids (for example IP
+ * Intelligence data files, or reduced size data files). Given a profile
+ * offset and the index of an available property the index of the first value
+ * can be returned by calling
+ * fiftyoneDegreesIndicesPropertyProfileLookupByOffset.
+ * @param profiles collection of variable sized profiles to be indexed
+ * @param profileOffsets collection of fixed entries which contain, or are,
+ * offsets to the profiles to be indexed
+ * @param offsetValueExtractor function which returns the pure profile offset
+ * from an entry in the profileOffsets collection
+ * @param available properties provided by the caller
+ * @param values collection to be indexed
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h
+ * @return pointer to the index memory structure, or NULL if the index could
+ * not be created
+ */
+EXTERNAL fiftyoneDegreesIndicesPropertyProfile*
+fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets(
+	fiftyoneDegreesCollection* profiles,
+	fiftyoneDegreesCollection* profileOffsets,
+	fiftyoneDegreesProfileOffsetValueExtractor offsetValueExtractor,
+	fiftyoneDegreesPropertiesAvailable* available,
+	fiftyoneDegreesCollection* values,
+	fiftyoneDegreesException* exception);
+
+/**
+ * Frees an index previously created by
  * fiftyoneDegreesIndicesPropertyProfileCreate.
  * @param index to be freed
  */
@@ -162,6 +225,26 @@ EXTERNAL uint32_t fiftyoneDegreesIndicesPropertyProfileLookup(
 	fiftyoneDegreesIndicesPropertyProfile* index,
 	uint32_t profileId,
 	uint32_t availablePropertyIndex);
+
+/**
+ * For a given profile offset and available property index returns the first
+ * value index via the firstValueIndex parameter. Only for use with indexes
+ * created by fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets. A
+ * returned first value index of UINT32_MAX means the profile is known to the
+ * index and has no values for the property.
+ * @param index from fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets
+ * @param profileOffset offset of the profile in the profiles collection
+ * @param availablePropertyIndex in the list of required properties
+ * @param firstValueIndex set to the index in the list of values for the
+ * profile for the first value associated with the property
+ * @return true if the profile offset is known to the index and
+ * firstValueIndex was set, otherwise false
+ */
+EXTERNAL bool fiftyoneDegreesIndicesPropertyProfileLookupByOffset(
+	const fiftyoneDegreesIndicesPropertyProfile* index,
+	uint32_t profileOffset,
+	uint32_t availablePropertyIndex,
+	uint32_t* firstValueIndex);
 
 /**
  * @}

--- a/profile.c
+++ b/profile.c
@@ -520,6 +520,49 @@ uint32_t fiftyoneDegreesProfileIterateValuesForPropertyWithIndex(
 #endif
 }
 
+uint32_t fiftyoneDegreesProfileIterateValuesForPropertyWithIndexAndOffset(
+	const fiftyoneDegreesCollection* values,
+	const fiftyoneDegreesIndicesPropertyProfile* index,
+	uint32_t availablePropertyIndex,
+	uint32_t profileOffset,
+	const fiftyoneDegreesProfile* profile,
+	const fiftyoneDegreesProperty* property,
+	void* state,
+	fiftyoneDegreesProfileIterateMethod callback,
+	fiftyoneDegreesException* exception) {
+	uint32_t i;
+	if (IndicesPropertyProfileLookupByOffset(
+		index,
+		profileOffset,
+		availablePropertyIndex,
+		&i)) {
+		if (i < profile->valueCount) {
+			const uint32_t* firstValueIndex =
+				((const uint32_t*)(profile + 1)) + i;
+			return iterateValues(
+				values,
+				property,
+				state,
+				callback,
+				firstValueIndex,
+				((const uint32_t*)(profile + 1)) + profile->valueCount,
+				exception);
+		}
+		// The profile is known to the index and has no values for the
+		// property.
+		return 0;
+	}
+	// The profile offset is not known to the index, so fall back to searching
+	// the values associated with the profile.
+	return fiftyoneDegreesProfileIterateValuesForProperty(
+		values,
+		profile,
+		property,
+		state,
+		callback,
+		exception);
+}
+
 uint32_t fiftyoneDegreesProfileIterateProfilesForPropertyAndValue(
 	fiftyoneDegreesCollection *strings,
 	fiftyoneDegreesCollection *properties,

--- a/profile.h
+++ b/profile.h
@@ -124,13 +124,9 @@ typedef struct fiftyoneDegrees_profile_offset_t {
 } fiftyoneDegreesProfileOffset;
 #pragma pack(pop)
 
-/**
- * Function that extracts "pure" profile offset
- * from a value inside `profileOffsets` collection
- * @param rawProfileOffset a "raw" value retrieved from `profileOffsets`
- * @return Offset to the profile in the profiles structure
- */
-typedef uint32_t (*fiftyoneDegreesProfileOffsetValueExtractor)(const void *rawProfileOffset);
+// The fiftyoneDegreesProfileOffsetValueExtractor typedef is declared in
+// indices.h (included above) so that it can also be used by the property
+// profile index methods.
 
 /**
  * Function that extracts "pure" profile offset
@@ -281,6 +277,38 @@ EXTERNAL uint32_t fiftyoneDegreesProfileIterateValuesForPropertyWithIndex(
 	const fiftyoneDegreesCollection* values,
 	fiftyoneDegreesIndicesPropertyProfile* index,
 	uint32_t availablePropertyIndex,
+	const fiftyoneDegreesProfile* profile,
+	const fiftyoneDegreesProperty* property,
+	void* state,
+	fiftyoneDegreesProfileIterateMethod callback,
+	fiftyoneDegreesException* exception);
+
+/**
+ * Iterate over all values contained in the profile which relate to the
+ * specified property, calling the callback method for each. Uses an index
+ * created by fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets and keyed
+ * by the profile offset, so is suitable for data files where the profiles do
+ * not contain profile ids. If the profile offset is not known to the index
+ * then the method falls back to
+ * fiftyoneDegreesProfileIterateValuesForProperty.
+ * @param values collection containing all values
+ * @param index of property and profile first value indexes keyed by profile
+ * offset
+ * @param availablePropertyIndex the index of the available property
+ * @param profileOffset offset of the profile in the profiles collection
+ * @param profile pointer to the profile to iterate the values of
+ * @param property which the values must relate to
+ * @param state pointer containing data needed for the callback method
+ * @param callback method to be called for each value
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h
+ * @return the number of matching values which have been iterated
+ */
+EXTERNAL uint32_t fiftyoneDegreesProfileIterateValuesForPropertyWithIndexAndOffset(
+	const fiftyoneDegreesCollection* values,
+	const fiftyoneDegreesIndicesPropertyProfile* index,
+	uint32_t availablePropertyIndex,
+	uint32_t profileOffset,
 	const fiftyoneDegreesProfile* profile,
 	const fiftyoneDegreesProperty* property,
 	void* state,


### PR DESCRIPTION
Implements the index infrastructure needed for 51Degrees/ip-intelligence-cxx#96.

## What

Adds a **profile offset keyed** variant of the property value index for data
files that contain no profile ids (`FIFTYONE_DEGREES_REDUCED_FILE`, used by IP
Intelligence), where the existing profile id keyed index
(`IndicesPropertyProfileCreate` / `IndicesPropertyProfileLookup` /
`ProfileIterateValuesForPropertyWithIndex`) is compiled out as
`NOT_IMPLEMENTED`.

- `fiftyoneDegreesIndicesPropertyProfileCreateFromOffsets(profiles,
  profileOffsets, offsetValueExtractor, available, values, exception)` — builds
  a sorted, de-duplicated array of pure profile offsets plus a dense
  `profileCount × availablePropertyCount` matrix of first value indexes.
  `UINT32_MAX` marks a profile with no values for the property. Entries of the
  `profileOffsets` collection are read through a caller supplied extractor
  (`ProfileOffsetToPureOffset` for full size files, `ProfileOffsetAsPureOffset`
  for plain uint32 entries), following the existing
  `ProfileIterateProfilesForPropertyWithTypeAndValueAndOffsetExtractor`
  precedent.
- `fiftyoneDegreesIndicesPropertyProfileLookupByOffset` — binary searches the
  sorted offsets for the row; returns `false` when the offset is unknown or the
  index is not offset keyed.
- `fiftyoneDegreesProfileIterateValuesForPropertyWithIndexAndOffset` — iterates
  the values for a property using the lookup, falling back to
  `ProfileIterateValuesForProperty` for offsets unknown to the index. Compiled
  in both reduced and full size builds.

## Refactoring notes

- `addProfileValuesMethod` (the fill logic) is now shared by both keyings — it
  takes the row base as a parameter instead of deriving it from
  `profile->profileId`, so it also compiles under `REDUCED_FILE`.
- The profile id keyed `Create`/`Lookup` are now stubbed as whole functions
  under `REDUCED_FILE` with unchanged observable behaviour
  (`NOT_IMPLEMENTED` exception / never called).
- The `fiftyoneDegreesProfileOffsetValueExtractor` typedef moves from
  `profile.h` to `indices.h` so both headers can use it; `profile.h` includes
  `indices.h`, so existing consumers are unaffected.
- `IndicesPropertyProfileFree` releases the new offsets array;
  the existing create sets it to `NULL`.

**Device detection (full size) behaviour is unchanged** — the profile id keyed
path is bit-for-bit the same.

## Testing

- Consumed by the companion ip-intelligence-cxx PR, whose new
  `IpiIndexParityTests` verify identical has-values state, value counts,
  weightings and value strings with and without the index (passes against the
  ASN and 4.5 Enterprise IPI data files).
- Full Release build clean under MSVC `/W4 /WX` in both reduced
  (ip-intelligence-cxx) and full size configurations.

## Context

Measurements in 51Degrees/ip-intelligence-cxx#96 show the index does **not**
improve IP Intelligence detection performance (see the issue for the analysis);
the companion PR therefore ships it disabled in all preset configurations.
This PR only provides the mechanism; it changes no defaults.
