### PR TITLE
Carry engine state into a reloaded data set

### DIFF
--- a/RequiredPropertiesConfig.cpp
+++ b/RequiredPropertiesConfig.cpp
@@ -39,6 +39,7 @@ RequiredPropertiesConfig::RequiredPropertiesConfig() {
 	conf.array = nullptr;
 	conf.existing = nullptr;
 	conf.string = nullptr;
+	conf.state = nullptr;
 }
 
 RequiredPropertiesConfig::RequiredPropertiesConfig(

--- a/dataset.c
+++ b/dataset.c
@@ -117,6 +117,7 @@ void fiftyoneDegreesDataSetReset(fiftyoneDegreesDataSetBase *dataSet) {
 	dataSet->overridable = NULL;
 	dataSet->indexPropertyProfile = NULL;
 	dataSet->config = NULL;
+	dataSet->state = NULL;
 	dataSet->handle = NULL;
 }
 
@@ -140,8 +141,10 @@ fiftyoneDegreesStatusCode fiftyoneDegreesDataSetInitProperties(
 		return REQ_PROP_NOT_PRESENT;
 	}
 
-	// Check there are properties available for retrieval.
-	if (dataSet->available->count == 0) {
+	// Check there are properties available for retrieval. Where the engine has
+	// provided state it can produce output which is not a stored property, so
+	// an empty set is legitimate.
+	if (dataSet->available->count == 0 && dataSet->state == NULL) {
 		return REQ_PROP_NOT_PRESENT;
 	}
 
@@ -281,6 +284,7 @@ fiftyoneDegreesStatusCode fiftyoneDegreesDataSetReloadManagerFromMemory(
 	// Reference the properties and config from the existing data set in the
 	// replacement.
 	properties.existing = ((DataSetBase*)manager->active->resource)->available;
+	properties.state = ((DataSetBase*)manager->active->resource)->state;
 	config = ((DataSetBase*)manager->active->resource)->config;
 
 	// Allocate memory for the replacement dataset.
@@ -323,6 +327,7 @@ fiftyoneDegreesStatusCode fiftyoneDegreesDataSetReloadManagerFromFile(
 	// Reference the properties and config from the existing data set in the
 	// replacement.
 	properties.existing = ((DataSetBase*)manager->active->resource)->available;
+	properties.state = ((DataSetBase*)manager->active->resource)->state;
 	config = ((DataSetBase*)manager->active->resource)->config;
 	
 	// Allocate memory for the replacement dataset.

--- a/dataset.h
+++ b/dataset.h
@@ -132,6 +132,11 @@ typedef struct fiftyone_degrees_dataset_base_t {
 															   values by 
 															   property */
     const void *config; /**< Pointer to the config used to create the dataset */
+	const void *state; /**< Pointer to the engine specific state the data set
+	                       was created with, or NULL. Opaque here: it is set by
+	                       the engine to its own copy so that a reload can pass
+	                       it to the replacement data set through
+	                       #fiftyoneDegreesPropertiesRequired.state */
 } fiftyoneDegreesDataSetBase;
 
 /**

--- a/fiftyone.h
+++ b/fiftyone.h
@@ -276,6 +276,7 @@ MAP_TYPE(WeightedItemList)
 #define FileDelete fiftyoneDegreesFileDelete /**< Synonym for #fiftyoneDegreesFileDelete function. */
 #define FilePoolReset fiftyoneDegreesFilePoolReset /**< Synonym for #fiftyoneDegreesFilePoolReset function. */
 #define PropertiesCreate fiftyoneDegreesPropertiesCreate /**< Synonym for #fiftyoneDegreesPropertiesCreate function. */
+#define PropertiesRequiredContains fiftyoneDegreesPropertiesRequiredContains /**< Synonym for #fiftyoneDegreesPropertiesRequiredContains function. */
 #define HeadersIsPseudo fiftyoneDegreesHeadersIsPseudo /**< Synonym for #fiftyoneDegreesHeadersIsPseudo function. */
 #define HeadersCreate fiftyoneDegreesHeadersCreate /**< Synonym for #fiftyoneDegreesHeadersCreate function. */
 #define HeadersGetHeaderFromUniqueId fiftyoneDegreesHeadersGetHeaderFromUniqueId /**< Synonym for #fiftyoneDegreesHeadersGetHeaderFromUniqueId function. */

--- a/properties.c
+++ b/properties.c
@@ -30,7 +30,8 @@ PropertiesRequired PropertiesDefault = {
 	NULL, // No array of properties
 	0, // No required properties
 	NULL, // No string with properties
-	NULL // No list
+	NULL, // No list
+	NULL // No engine state
 };
 
 typedef struct properties_source_t {
@@ -241,14 +242,47 @@ static uint32_t countPropertiesFromExisting(
 	return counter.count;
 }
 
+bool fiftyoneDegreesPropertiesRequiredContains(
+	PropertiesRequired *properties,
+	const char *propertyName) {
+	if (properties == NULL || propertyName == NULL) {
+		return false;
+	}
+	const size_t length = strlen(propertyName);
+	if (properties->array != NULL && properties->count > 0) {
+		for (int i = 0; i < properties->count; i++) {
+			if (properties->array[i] != NULL &&
+				strlen(properties->array[i]) == length &&
+				_strnicmp(properties->array[i], propertyName, length) == 0) {
+				return true;
+			}
+		}
+	}
+	else if (properties->string != NULL) {
+		const char *start = properties->string;
+		const char *end = start;
+		while (true) {
+			if (*end == '\0' || strchr(separators, *end) != NULL) {
+				if ((size_t)(end - start) == length &&
+					_strnicmp(start, propertyName, length) == 0) {
+					return true;
+				}
+				if (*end == '\0') {
+					break;
+				}
+				start = end + 1;
+			}
+			end++;
+		}
+	}
+	return false;
+}
+
 static PropertiesAvailable* initRequiredPropertiesFromString(
 	propertiesSource *source,
 	const char* properties) {
 	PropertiesAvailable *available;
 	uint32_t count = countPropertiesFromString(source, properties);
-	if (count == 0) {
-		return NULL;
-	}
 	available = initRequiredPropertiesMemory(count);
 	if (available != NULL) {
 		iteratePropertiesFromString(

--- a/properties.h
+++ b/properties.h
@@ -182,6 +182,14 @@ EXTERNAL typedef struct fiftyone_degrees_properties_required_t {
 	fiftyoneDegreesPropertiesAvailable *existing; /**< A pointer to an existing
 	                                                  set of property names
 													  from another instance */
+	const void *state; /**< Engine specific state to carry into the data set,
+	                       or NULL. Opaque here: it is copied by the engine
+	                       during initialisation, and returned to the engine
+	                       across a reload via
+	                       #fiftyoneDegreesDataSetBase.state. Where it is set
+	                       the engine can produce output without any stored
+	                       property, so an empty set of available properties is
+	                       not an error. */
 } fiftyoneDegreesPropertiesRequired;
 
 /**
@@ -221,6 +229,20 @@ typedef uint32_t(*fiftyoneDegreesEvidencePropertiesGetMethod)(
  * #fiftyoneDegreesPropertiesRequired.
  */
 EXTERNAL_VAR fiftyoneDegreesPropertiesRequired fiftyoneDegreesPropertiesDefault;
+
+/**
+ * Returns true if the required properties name the property provided. Used by
+ * engines to recognise a name which is not a property in the data file, and so
+ * cannot be resolved by #fiftyoneDegreesPropertiesCreate. The comparison
+ * ignores case, and the array and string forms are considered in the same
+ * order of precedence as #fiftyoneDegreesPropertiesCreate.
+ * @param properties required by the caller, or NULL
+ * @param propertyName to look for
+ * @return true if the name is present in the required properties
+ */
+EXTERNAL bool fiftyoneDegreesPropertiesRequiredContains(
+	fiftyoneDegreesPropertiesRequired *properties,
+	const char *propertyName);
 
 /**
  * Creates a properties result instance for use with future property 


### PR DESCRIPTION
Draft. Prerequisite for 51Degrees/device-detection-cxx#395 - the device-detection change is raised separately and pins its submodule at this branch.

## Why

An engine may need state derived from the properties the caller asked for rather than read from the data file. Device detection needs it for the device id: that is composed from the profile of every component, is not a stored property, and so cannot be resolved by `PropertiesCreate`.

Such a request cannot survive a reload today. `DataSetReloadManagerFrom[File|Memory]` rebuilds the required properties from the previous data set's *available* properties, and that list by construction only ever contains names found in the data file.

## What changed

An opaque `state` pointer alongside `config`, carried exactly the way `config` already is - read off the old data set, passed in through `PropertiesRequired`, copied by the engine into its own typed field during init. common-cxx never needs its size or its type.

- `PropertiesRequired.state` - the way in. NULL in `PropertiesDefault`.
- `DataSetBase.state` - so a reload can read it back out. `DataSetReset` clears it like every other field; it always arrives as an input, so there is no preserved-garbage case.
- Both reload functions carry it, one line each, next to the existing `available` and `config` lines.
- `DataSetInitProperties` returns `REQ_PROP_NOT_PRESENT` for an empty set of available properties **unless** the engine has set the state, in which case that engine can produce output with no stored property. Engines which do not set it - IP intelligence, ip-graph - are unaffected and keep the current error.
- `PropertiesRequiredContains`, so an engine can recognise a requested name that is not in the data file without reimplementing separator handling and case-insensitive matching.
- A required-properties string matching nothing now returns an empty set rather than NULL, leaving NULL to mean an allocation failure. The status returned to callers is unchanged.

## Note for reviewers

`RequiredPropertiesConfig` built its `PropertiesRequired` member field by member rather than copying `PropertiesDefault`, so the new pointer was uninitialised and got dereferenced - a segfault across the whole C++ engine suite until fixed here. Aggregate initialisers such as `= { NULL, 0, "...", NULL }` are safe, since unlisted members are zeroed. Anything that declares a `PropertiesRequired` and then assigns fields must set `state`, or copy `PropertiesDefault` as the documentation already advises. Worth a look at other consumers before this is picked up downstream.

Both structs change size, so consumers rebuild on the submodule bump.

## Testing

Exercised through device-detection-cxx: 961/961 of its Hash suite passes, including reload and the empty-available-properties path. Clean under `-Werror` across all targets and in the `MemoryOnly` configuration; the suite's Linux allocation tracking reports no leaks.