### PR TITLE
FEAT: Collections can convert stored offsets to bytes with a shift

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -31,6 +31,27 @@ MAP_TYPE(CollectionConfig)
 #endif
 
 /**
+ * Converts a stored offset, or the stored size, of a collection to bytes.
+ * Only variable length collections created with an offset shift store these
+ * in units larger than a byte, and only when compiled with large data file
+ * support. Every other collection uses a shift of zero, and builds without
+ * large data file support compile to the value unchanged so behaviour and
+ * performance are identical to before the shift was introduced.
+ */
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+#define COLLECTION_UNITS_TO_BYTES(s, v) (((uint64_t)(v)) << (s))
+#define COLLECTION_OFFSET_SHIFT(c) ((c)->offsetShift)
+#else
+#define COLLECTION_UNITS_TO_BYTES(s, v) (v)
+#define COLLECTION_OFFSET_SHIFT(c) 0
+#endif
+
+static fiftyoneDegreesCollection* collectionCreateFromMemory(
+	fiftyoneDegreesMemoryReader *reader,
+	fiftyoneDegreesCollectionHeader header,
+	byte offsetShift);
+
+/**
  * Used by methods which retrieve values from a collection to set an exception.
  */
 #ifndef FIFTYONE_DEGREES_EXCEPTIONS_DISABLED
@@ -196,7 +217,9 @@ static void* getMemoryVariable(
 	Exception *exception) {
 	CollectionMemory *memory = (CollectionMemory*)collection->state;
 	if (key->indexOrOffset.offset < collection->size) {
-		item->data.ptr = memory->firstByte + key->indexOrOffset.offset;
+		item->data.ptr = memory->firstByte + (size_t)COLLECTION_UNITS_TO_BYTES(
+			COLLECTION_OFFSET_SHIFT(collection),
+			key->indexOrOffset.offset);
 		assert(item->data.ptr < memory->lastByte);
 		item->collection = collection;
 	}
@@ -358,8 +381,12 @@ static void loaderCache(
 static Collection* createCollection(
 	size_t sizeOfState,
 	CollectionHeader *header,
-	const char * const typeName) {
+	const char * const typeName,
+	byte offsetShift) {
 	Collection *collection = (Collection*)Malloc(sizeof(Collection));
+#ifndef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+	(void)offsetShift;
+#endif
 	if (collection != NULL) {
 		collection->state = Malloc(sizeOfState);
 		collection->typeName = typeName;
@@ -368,6 +395,9 @@ static Collection* createCollection(
 				0 : header->length / header->count;
 			collection->size = header->length;
 			collection->count = header->count;
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+			collection->offsetShift = offsetShift;
+#endif
 		}
 		else {
 			Free(collection);
@@ -380,7 +410,7 @@ static Collection* createCollection(
 #ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 
 static CollectionFile* readFile(CollectionFile *fileCollection, FILE *file) {
-	
+
 	// Set the count of items if not already set and the elements are of a
 	// fixed size.
 	if (fileCollection->collection->count == 0 &&
@@ -393,7 +423,12 @@ static CollectionFile* readFile(CollectionFile *fileCollection, FILE *file) {
 	fileCollection->offset = FileTell(file);
 
 	// Move the file handle past the collection.
-	if (FileSeek(file, fileCollection->collection->size, SEEK_CUR) != 0) {
+	if (FileSeek(
+		file,
+		(FileOffset)COLLECTION_UNITS_TO_BYTES(
+			COLLECTION_OFFSET_SHIFT(fileCollection->collection),
+			fileCollection->collection->size),
+		SEEK_CUR) != 0) {
 		return NULL;
 	}
 
@@ -404,13 +439,15 @@ static Collection* createFromFile(
 	FILE *file,
 	FilePool *reader,
 	CollectionHeader *header,
-	CollectionFileRead read) {
+	CollectionFileRead read,
+	byte offsetShift) {
 
 	// Allocate the memory for the collection and file implementation.
 	Collection *collection = createCollection(
 		sizeof(CollectionFile),
 		header,
-		"CollectionFile");
+		"CollectionFile",
+		offsetShift);
 	CollectionFile *fileCollection = (CollectionFile*)collection->state;
 	fileCollection->collection = collection;
 	fileCollection->reader = reader;
@@ -436,9 +473,13 @@ static Collection* createFromFile(
 
 static Collection* createFromFileToMemory(
 	FILE *file,
-	CollectionHeader header) {
+	CollectionHeader header,
+	byte offsetShift) {
 	EXCEPTION_CREATE;
-	byte * const data = (byte*)Malloc(header.length * sizeof(byte));
+	const size_t lengthInBytes = (size_t)COLLECTION_UNITS_TO_BYTES(
+		offsetShift,
+		header.length);
+	byte * const data = (byte*)Malloc(lengthInBytes * sizeof(byte));
 	MemoryReader memory;
 
 	memory.current = data;
@@ -448,7 +489,7 @@ static Collection* createFromFileToMemory(
 	}
 
 	memory.startByte = memory.current;
-	memory.length = (FileOffset)header.length;
+	memory.length = (FileOffset)lengthInBytes;
 	memory.lastByte = memory.current + memory.length;
 
 	// Position the file reader at the start of the collection.
@@ -458,13 +499,16 @@ static Collection* createFromFileToMemory(
 	}
 
 	// Read the portion of the file into memory.
-	if (fread(memory.startByte, 1, header.length, file) != header.length) {
+	if (fread(memory.startByte, 1, lengthInBytes, file) != lengthInBytes) {
 		Free(data);
 		return NULL;
 	}
 
 	header.startPosition = 0;
-	Collection * const result = CollectionCreateFromMemory(&memory, header);
+	Collection * const result = collectionCreateFromMemory(
+		&memory,
+		header,
+		offsetShift);
 
 	if (result == NULL) {
 		Free(data);
@@ -484,18 +528,20 @@ static Collection* createFromFileCached(
 	CollectionHeader *header,
 	uint32_t capacity,
 	uint16_t concurrency,
-	CollectionFileRead read) {
+	CollectionFileRead read,
+	byte offsetShift) {
 
 	// Allocate the memory for the collection and implementation.
 	Collection *collection = createCollection(
 		sizeof(CollectionFile),
 		header,
-		"CollectionCache");
+		"CollectionCache",
+		offsetShift);
 	CollectionCache *cache = (CollectionCache*)collection->state;
 	cache->cache = NULL;
 
 	// Create the file collection to be used with the cache.
-	cache->source = createFromFile(file, reader, header, read);
+	cache->source = createFromFile(file, reader, header, read, offsetShift);
 	if (cache->source == NULL) {
 		freeCacheCollection(collection);
 		return NULL;
@@ -534,7 +580,8 @@ static Collection* createFromFileMaybeCached(
 	FilePool *reader,
 	const CollectionConfig *config,
 	CollectionHeader header,
-	CollectionFileRead read) {
+	CollectionFileRead read,
+	byte offsetShift) {
 
 	// Return the file position to the start of the collection ready to
 	// read the next collection.
@@ -543,7 +590,7 @@ static Collection* createFromFileMaybeCached(
 		// Choose between the cached or file based collection.
 		if (config->capacity > 0 && config->concurrency > 0) {
 
-			// If the collection should have a cache then set the next 
+			// If the collection should have a cache then set the next
 			// collection to be cache based.
 			return createFromFileCached(
 				file,
@@ -551,13 +598,14 @@ static Collection* createFromFileMaybeCached(
 				&header,
 				config->capacity,
 				config->concurrency,
-				read);
+				read,
+				offsetShift);
 		}
 		else {
 
-			// If there is no cache then the entries will be fetched 
+			// If there is no cache then the entries will be fetched
 			// directly from the source file.
-			return createFromFile(file, reader, &header, read);
+			return createFromFile(file, reader, &header, read, offsetShift);
 		}
 	}
 
@@ -593,9 +641,10 @@ fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromMemory(
 	return header;
 }
 
-fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
+static fiftyoneDegreesCollection* collectionCreateFromMemory(
 	fiftyoneDegreesMemoryReader *reader,
-	fiftyoneDegreesCollectionHeader header) {
+	fiftyoneDegreesCollectionHeader header,
+	byte offsetShift) {
 
 	// Validate the header and the reader are in sync at the correct position.
 	if ((FileOffsetUnsigned)(reader->current - reader->startByte) !=
@@ -607,16 +656,19 @@ fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
 	Collection *collection = createCollection(
 		sizeof(CollectionMemory),
 		&header,
-		"CollectionMemory");
+		"CollectionMemory",
+		offsetShift);
 	CollectionMemory *memory = (CollectionMemory*)collection->state;
 
 	// Configure the fields for the collection.
 	memory->collection = collection;
 	memory->memoryToFree = NULL;
-	memory->collection->elementSize = header.count == 0 ? 
+	memory->collection->elementSize = header.count == 0 ?
 		0 : header.length / header.count;
 	memory->firstByte = reader->current;
-	memory->lastByte = memory->firstByte + memory->collection->size;
+	memory->lastByte = memory->firstByte + (size_t)COLLECTION_UNITS_TO_BYTES(
+		offsetShift,
+		memory->collection->size);
 
 	// Assign the get and release functions for the collection.
 	if (memory->collection->elementSize != 0) {
@@ -635,17 +687,37 @@ fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
 	}
 	collection->freeCollection = freeMemoryCollection;
 
-	// Move over the structure and the size integer checking the move 
+	// Move over the structure and the size integer checking the move
 	// operation was successful.
 	if (MemoryAdvance(
 		reader,
-		memory->collection->size) == false) {
+		(size_t)COLLECTION_UNITS_TO_BYTES(
+			offsetShift,
+			memory->collection->size)) == false) {
 		collection->freeCollection(collection);
 		collection = NULL;
 	}
 
 	return collection;
 }
+
+fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
+	fiftyoneDegreesMemoryReader *reader,
+	fiftyoneDegreesCollectionHeader header) {
+	return collectionCreateFromMemory(reader, header, 0);
+}
+
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+
+fiftyoneDegreesCollection*
+fiftyoneDegreesCollectionCreateFromMemoryWithOffsetShift(
+	fiftyoneDegreesMemoryReader *reader,
+	fiftyoneDegreesCollectionHeader header,
+	byte offsetShift) {
+	return collectionCreateFromMemory(reader, header, offsetShift);
+}
+
+#endif
 
 fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromFile(
 	FILE *file,
@@ -676,16 +748,23 @@ fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromFile(
 	return header;
 }
 
-fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
+static fiftyoneDegreesCollection* collectionCreateFromFile(
 	FILE *file,
 	fiftyoneDegreesFilePool *reader,
 	const fiftyoneDegreesCollectionConfig *config,
 	fiftyoneDegreesCollectionHeader header,
-	fiftyoneDegreesCollectionFileRead read) {
+	fiftyoneDegreesCollectionFileRead read,
+	byte offsetShift) {
 
 #ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 	if (!config->loaded) {
-		return createFromFileMaybeCached(file, reader, config, header, read);
+		return createFromFileMaybeCached(
+			file,
+			reader,
+			config,
+			header,
+			read,
+			offsetShift);
 	}
 #else
 #	ifdef _MSC_VER
@@ -695,8 +774,38 @@ fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
 #	endif
 #endif
 
-	return createFromFileToMemory(file, header);
+	return createFromFileToMemory(file, header, offsetShift);
 }
+
+fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
+	FILE *file,
+	fiftyoneDegreesFilePool *reader,
+	const fiftyoneDegreesCollectionConfig *config,
+	fiftyoneDegreesCollectionHeader header,
+	fiftyoneDegreesCollectionFileRead read) {
+	return collectionCreateFromFile(file, reader, config, header, read, 0);
+}
+
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+
+fiftyoneDegreesCollection*
+fiftyoneDegreesCollectionCreateFromFileWithOffsetShift(
+	FILE *file,
+	fiftyoneDegreesFilePool *reader,
+	const fiftyoneDegreesCollectionConfig *config,
+	fiftyoneDegreesCollectionHeader header,
+	fiftyoneDegreesCollectionFileRead read,
+	byte offsetShift) {
+	return collectionCreateFromFile(
+		file,
+		reader,
+		config,
+		header,
+		read,
+		offsetShift);
+}
+
+#endif
 
 fiftyoneDegreesFileHandle* fiftyoneDegreesCollectionReadFilePosition(
 	const fiftyoneDegreesCollectionFile *file,
@@ -807,8 +916,14 @@ static void* readFileVariable(
 	uint32_t bytesNeeded, leftToRead;
 	void *ptr = NULL;
 
-	// Set the file position to the start of the item being read.
-	if (FileSeek(handle->file, fileCollection->offset + offset, SEEK_SET) == 0) {
+	// Set the file position to the start of the item being read. The offset
+	// is converted from the collection's offset units to bytes.
+	if (FileSeek(
+		handle->file,
+		fileCollection->offset + (FileOffset)COLLECTION_UNITS_TO_BYTES(
+			COLLECTION_OFFSET_SHIFT(fileCollection->collection),
+			offset),
+		SEEK_SET) == 0) {
 
 		// Read the item header minus the last part of the structure 
 		// that may not always be included with every item.

--- a/collection.c
+++ b/collection.c
@@ -46,10 +46,24 @@ MAP_TYPE(CollectionConfig)
 #define COLLECTION_OFFSET_SHIFT(c) 0
 #endif
 
+/**
+ * Add the offset shift parameter to the internal creation methods, and pass
+ * it between them, only when compiled with large data file support. Without
+ * it the signatures and calls compile exactly as they did before the shift
+ * was introduced.
+ */
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+#define COLLECTION_SHIFT_PARAM , byte offsetShift
+#define COLLECTION_SHIFT_ARG(s) , s
+#else
+#define COLLECTION_SHIFT_PARAM
+#define COLLECTION_SHIFT_ARG(s)
+#endif
+
 static fiftyoneDegreesCollection* collectionCreateFromMemory(
 	fiftyoneDegreesMemoryReader *reader,
-	fiftyoneDegreesCollectionHeader header,
-	byte offsetShift);
+	fiftyoneDegreesCollectionHeader header
+	COLLECTION_SHIFT_PARAM);
 
 /**
  * Used by methods which retrieve values from a collection to set an exception.
@@ -381,12 +395,9 @@ static void loaderCache(
 static Collection* createCollection(
 	size_t sizeOfState,
 	CollectionHeader *header,
-	const char * const typeName,
-	byte offsetShift) {
+	const char * const typeName
+	COLLECTION_SHIFT_PARAM) {
 	Collection *collection = (Collection*)Malloc(sizeof(Collection));
-#ifndef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
-	(void)offsetShift;
-#endif
 	if (collection != NULL) {
 		collection->state = Malloc(sizeOfState);
 		collection->typeName = typeName;
@@ -439,15 +450,15 @@ static Collection* createFromFile(
 	FILE *file,
 	FilePool *reader,
 	CollectionHeader *header,
-	CollectionFileRead read,
-	byte offsetShift) {
+	CollectionFileRead read
+	COLLECTION_SHIFT_PARAM) {
 
 	// Allocate the memory for the collection and file implementation.
 	Collection *collection = createCollection(
 		sizeof(CollectionFile),
 		header,
-		"CollectionFile",
-		offsetShift);
+		"CollectionFile"
+		COLLECTION_SHIFT_ARG(offsetShift));
 	CollectionFile *fileCollection = (CollectionFile*)collection->state;
 	fileCollection->collection = collection;
 	fileCollection->reader = reader;
@@ -473,8 +484,8 @@ static Collection* createFromFile(
 
 static Collection* createFromFileToMemory(
 	FILE *file,
-	CollectionHeader header,
-	byte offsetShift) {
+	CollectionHeader header
+	COLLECTION_SHIFT_PARAM) {
 	EXCEPTION_CREATE;
 	const size_t lengthInBytes = (size_t)COLLECTION_UNITS_TO_BYTES(
 		offsetShift,
@@ -507,8 +518,8 @@ static Collection* createFromFileToMemory(
 	header.startPosition = 0;
 	Collection * const result = collectionCreateFromMemory(
 		&memory,
-		header,
-		offsetShift);
+		header
+		COLLECTION_SHIFT_ARG(offsetShift));
 
 	if (result == NULL) {
 		Free(data);
@@ -528,20 +539,25 @@ static Collection* createFromFileCached(
 	CollectionHeader *header,
 	uint32_t capacity,
 	uint16_t concurrency,
-	CollectionFileRead read,
-	byte offsetShift) {
+	CollectionFileRead read
+	COLLECTION_SHIFT_PARAM) {
 
 	// Allocate the memory for the collection and implementation.
 	Collection *collection = createCollection(
 		sizeof(CollectionFile),
 		header,
-		"CollectionCache",
-		offsetShift);
+		"CollectionCache"
+		COLLECTION_SHIFT_ARG(offsetShift));
 	CollectionCache *cache = (CollectionCache*)collection->state;
 	cache->cache = NULL;
 
 	// Create the file collection to be used with the cache.
-	cache->source = createFromFile(file, reader, header, read, offsetShift);
+	cache->source = createFromFile(
+		file,
+		reader,
+		header,
+		read
+		COLLECTION_SHIFT_ARG(offsetShift));
 	if (cache->source == NULL) {
 		freeCacheCollection(collection);
 		return NULL;
@@ -580,8 +596,8 @@ static Collection* createFromFileMaybeCached(
 	FilePool *reader,
 	const CollectionConfig *config,
 	CollectionHeader header,
-	CollectionFileRead read,
-	byte offsetShift) {
+	CollectionFileRead read
+	COLLECTION_SHIFT_PARAM) {
 
 	// Return the file position to the start of the collection ready to
 	// read the next collection.
@@ -598,14 +614,19 @@ static Collection* createFromFileMaybeCached(
 				&header,
 				config->capacity,
 				config->concurrency,
-				read,
-				offsetShift);
+				read
+				COLLECTION_SHIFT_ARG(offsetShift));
 		}
 		else {
 
 			// If there is no cache then the entries will be fetched
 			// directly from the source file.
-			return createFromFile(file, reader, &header, read, offsetShift);
+			return createFromFile(
+				file,
+				reader,
+				&header,
+				read
+				COLLECTION_SHIFT_ARG(offsetShift));
 		}
 	}
 
@@ -643,8 +664,8 @@ fiftyoneDegreesCollectionHeader fiftyoneDegreesCollectionHeaderFromMemory(
 
 static fiftyoneDegreesCollection* collectionCreateFromMemory(
 	fiftyoneDegreesMemoryReader *reader,
-	fiftyoneDegreesCollectionHeader header,
-	byte offsetShift) {
+	fiftyoneDegreesCollectionHeader header
+	COLLECTION_SHIFT_PARAM) {
 
 	// Validate the header and the reader are in sync at the correct position.
 	if ((FileOffsetUnsigned)(reader->current - reader->startByte) !=
@@ -656,8 +677,8 @@ static fiftyoneDegreesCollection* collectionCreateFromMemory(
 	Collection *collection = createCollection(
 		sizeof(CollectionMemory),
 		&header,
-		"CollectionMemory",
-		offsetShift);
+		"CollectionMemory"
+		COLLECTION_SHIFT_ARG(offsetShift));
 	CollectionMemory *memory = (CollectionMemory*)collection->state;
 
 	// Configure the fields for the collection.
@@ -704,7 +725,7 @@ static fiftyoneDegreesCollection* collectionCreateFromMemory(
 fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
 	fiftyoneDegreesMemoryReader *reader,
 	fiftyoneDegreesCollectionHeader header) {
-	return collectionCreateFromMemory(reader, header, 0);
+	return collectionCreateFromMemory(reader, header COLLECTION_SHIFT_ARG(0));
 }
 
 #ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
@@ -714,7 +735,10 @@ fiftyoneDegreesCollectionCreateFromMemoryWithOffsetShift(
 	fiftyoneDegreesMemoryReader *reader,
 	fiftyoneDegreesCollectionHeader header,
 	byte offsetShift) {
-	return collectionCreateFromMemory(reader, header, offsetShift);
+	return collectionCreateFromMemory(
+		reader,
+		header
+		COLLECTION_SHIFT_ARG(offsetShift));
 }
 
 #endif
@@ -753,8 +777,8 @@ static fiftyoneDegreesCollection* collectionCreateFromFile(
 	fiftyoneDegreesFilePool *reader,
 	const fiftyoneDegreesCollectionConfig *config,
 	fiftyoneDegreesCollectionHeader header,
-	fiftyoneDegreesCollectionFileRead read,
-	byte offsetShift) {
+	fiftyoneDegreesCollectionFileRead read
+	COLLECTION_SHIFT_PARAM) {
 
 #ifndef FIFTYONE_DEGREES_MEMORY_ONLY
 	if (!config->loaded) {
@@ -763,8 +787,8 @@ static fiftyoneDegreesCollection* collectionCreateFromFile(
 			reader,
 			config,
 			header,
-			read,
-			offsetShift);
+			read
+			COLLECTION_SHIFT_ARG(offsetShift));
 	}
 #else
 #	ifdef _MSC_VER
@@ -774,7 +798,7 @@ static fiftyoneDegreesCollection* collectionCreateFromFile(
 #	endif
 #endif
 
-	return createFromFileToMemory(file, header, offsetShift);
+	return createFromFileToMemory(file, header COLLECTION_SHIFT_ARG(offsetShift));
 }
 
 fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
@@ -783,7 +807,13 @@ fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
 	const fiftyoneDegreesCollectionConfig *config,
 	fiftyoneDegreesCollectionHeader header,
 	fiftyoneDegreesCollectionFileRead read) {
-	return collectionCreateFromFile(file, reader, config, header, read, 0);
+	return collectionCreateFromFile(
+		file,
+		reader,
+		config,
+		header,
+		read
+		COLLECTION_SHIFT_ARG(0));
 }
 
 #ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
@@ -801,8 +831,8 @@ fiftyoneDegreesCollectionCreateFromFileWithOffsetShift(
 		reader,
 		config,
 		header,
-		read,
-		offsetShift);
+		read
+		COLLECTION_SHIFT_ARG(offsetShift));
 }
 
 #endif

--- a/collection.h
+++ b/collection.h
@@ -417,7 +417,17 @@ typedef struct fiftyone_degrees_collection_t {
 	uint32_t count; /**< The number of items, or 0 if not available */
 	uint32_t elementSize; /**< The size of each entry, or 0 if variable length */
 	uint32_t size; /**< Number of bytes in the source data structure containing
-					  the collection's data */
+					  the collection's data, or where offsetShift is non zero
+					  the number of offset units */
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+	byte offsetShift; /**< Number of bits to shift a stored offset, or the
+					  size field, left to convert it to bytes. Zero for all
+					  collections except variable length collections created
+					  with one of the WithOffsetShift methods, where records
+					  are aligned so that 32 bit stored offsets can address
+					  data larger than 4GB. Only available when compiled with
+					  large data file support. */
+#endif
 	const char *typeName; /**< Name of collection type (vtable). */
 } fiftyoneDegreesCollection;
 
@@ -515,6 +525,59 @@ EXTERNAL fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromFile(
 EXTERNAL fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
 	fiftyoneDegreesMemoryReader *reader,
 	fiftyoneDegreesCollectionHeader header);
+
+#ifdef FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT
+
+/**
+ * Creates a collection from the file handle as
+ * #fiftyoneDegreesCollectionCreateFromFile does, but for variable length
+ * collections whose stored offsets, and header length, are recorded in units
+ * of 1 << offsetShift bytes rather than in bytes. Records in such collections
+ * are aligned by the writer to 1 << offsetShift byte boundaries so that
+ * 32 bit stored offsets can address data larger than 4GB. Must not be used
+ * for fixed width collections. Only available when compiled with large data
+ * file support.
+ * @param file a file handle positioned at the start of the collection
+ * @param reader a pool of file handles to use operationally to retrieve data
+ * from the file after the collection has been created
+ * @param config settings for the implementation of the collection to be used
+ * @param header containing collection structure with the length in offset
+ * units
+ * @param read a pointer to a function to read an item into the collection
+ * @param offsetShift number of bits to shift a stored offset left to convert
+ * it to bytes, or zero for byte offsets
+ * @return pointer to the new collection, or NULL if something went wrong
+ */
+EXTERNAL fiftyoneDegreesCollection*
+fiftyoneDegreesCollectionCreateFromFileWithOffsetShift(
+	FILE *file,
+	fiftyoneDegreesFilePool *reader,
+	const fiftyoneDegreesCollectionConfig *config,
+	fiftyoneDegreesCollectionHeader header,
+	fiftyoneDegreesCollectionFileRead read,
+	byte offsetShift);
+
+/**
+ * Creates a collection from a memory reader as
+ * #fiftyoneDegreesCollectionCreateFromMemory does, but for variable length
+ * collections whose stored offsets, and header length, are recorded in units
+ * of 1 << offsetShift bytes rather than in bytes. See
+ * #fiftyoneDegreesCollectionCreateFromFileWithOffsetShift.
+ * @param reader with access to the allocated memory
+ * @param header containing collection structure with the length in offset
+ * units
+ * @param offsetShift number of bits to shift a stored offset left to convert
+ * it to bytes, or zero for byte offsets
+ * @return pointer to the memory collection, or NULL if the collection could
+ * not be created
+ */
+EXTERNAL fiftyoneDegreesCollection*
+fiftyoneDegreesCollectionCreateFromMemoryWithOffsetShift(
+	fiftyoneDegreesMemoryReader *reader,
+	fiftyoneDegreesCollectionHeader header,
+	byte offsetShift);
+
+#endif
 
 /**
  * Get a handle from the file pool associated with the collection and position

--- a/collection.h
+++ b/collection.h
@@ -424,9 +424,11 @@ typedef struct fiftyone_degrees_collection_t {
 					  size field, left to convert it to bytes. Zero for all
 					  collections except variable length collections created
 					  with one of the WithOffsetShift methods, where records
-					  are aligned so that 32 bit stored offsets can address
-					  data larger than 4GB. Only available when compiled with
-					  large data file support. */
+					  are aligned relative to the start of the collection so
+					  that 32 bit stored offsets can address data larger than
+					  4GB. The start of the collection itself need not be
+					  aligned. Only available when compiled with large data
+					  file support. */
 #endif
 	const char *typeName; /**< Name of collection type (vtable). */
 } fiftyoneDegreesCollection;
@@ -533,8 +535,10 @@ EXTERNAL fiftyoneDegreesCollection* fiftyoneDegreesCollectionCreateFromMemory(
  * #fiftyoneDegreesCollectionCreateFromFile does, but for variable length
  * collections whose stored offsets, and header length, are recorded in units
  * of 1 << offsetShift bytes rather than in bytes. Records in such collections
- * are aligned by the writer to 1 << offsetShift byte boundaries so that
- * 32 bit stored offsets can address data larger than 4GB. Must not be used
+ * are aligned by the writer to 1 << offsetShift byte boundaries relative to
+ * the start of the collection, which is what the stored offsets are relative
+ * to, so that 32 bit stored offsets can address data larger than 4GB. The
+ * start of the collection itself need not be aligned. Must not be used
  * for fixed width collections. Only available when compiled with large data
  * file support.
  * @param file a file handle positioned at the start of the collection


### PR DESCRIPTION
Adds an offset unit shift to collections so that variable length collections can store offsets, and the header length, in units larger than a byte. A 32 bit stored offset with an 8 byte unit addresses 32GB of data rather than 4GB.

The shift applies when a stored offset is converted to a memory or file position inside the collection (getMemoryVariable, readFileVariable and the byte size arithmetic at creation), so consumers keep passing the stored values and no reading signatures change. Two new creation functions, CollectionCreateFromMemoryWithOffsetShift and CollectionCreateFromFileWithOffsetShift, thread the shift into the single existing implementation; the existing creation functions delegate with a shift of zero and behave exactly as before.

Builds without FIFTYONE_DEGREES_LARGE_DATA_FILE_SUPPORT compile to the previous arithmetic with no new struct fields, and the new creation functions are not declared, so a shift cannot be introduced in builds that cannot address it.

Intended for the IP Intelligence profiles collection, which has reached three quarters of the 4GB limit. Fixed width collections must not be created with a shift as their file read path resolves indexes to byte offsets before the conversion applies.

The companion pull request 51Degrees/ip-intelligence-cxx#144 reads version 4.6 data files with shifted profile offsets. The exporter which writes them follows separately.

Verified by syntax checking with and without the compile flag. Not yet built or run against the test suites.